### PR TITLE
INTERLOK-2911 Add additional AWSCredentialsProvider builders

### DIFF
--- a/interlok-aws-common/src/main/java/com/adaptris/aws/AWSCredentialsProviderBuilder.java
+++ b/interlok-aws-common/src/main/java/com/adaptris/aws/AWSCredentialsProviderBuilder.java
@@ -14,7 +14,7 @@ public interface AWSCredentialsProviderBuilder {
    * Helper to log warnings when configuration contains an {@link AWSAuthentication} member rather
    * than a {@link AWSCredentialsProviderBuilder}.
    * 
-   * @deprecated will be removed as soon as {@link AWSAuthenication} is removed from various
+   * @deprecated will be removed as soon as {@link AWSAuthentication} is removed from various
    *             connections.
    */
   @Deprecated

--- a/interlok-aws-common/src/main/java/com/adaptris/aws/ProcessCredentialsBuilder.java
+++ b/interlok-aws-common/src/main/java/com/adaptris/aws/ProcessCredentialsBuilder.java
@@ -26,7 +26,7 @@ import lombok.Setter;
  * 
  */
 @XStreamAlias("aws-process-credentials-builder")
-@ComponentProfile(summary = "Credentials provider that can load credentials from an external process")
+@ComponentProfile(summary = "Credentials provider that can load credentials from an external process", since = "3.9.2")
 public class ProcessCredentialsBuilder implements AWSCredentialsProviderBuilder {
 
   /**

--- a/interlok-aws-common/src/main/java/com/adaptris/aws/ProcessCredentialsBuilder.java
+++ b/interlok-aws-common/src/main/java/com/adaptris/aws/ProcessCredentialsBuilder.java
@@ -1,0 +1,107 @@
+package com.adaptris.aws;
+
+import java.util.concurrent.TimeUnit;
+import org.hibernate.validator.constraints.NotBlank;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.InputFieldDefault;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.ProcessCredentialsProvider;
+import com.amazonaws.auth.ProcessCredentialsProvider.Builder;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+
+/**
+ * Credentials provider that can load credentials from an external process.
+ * 
+ * <p>
+ * See
+ * https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes
+ * for more information
+ * </p>
+ * 
+ * @config aws-process-credentials-builder
+ * 
+ */
+@XStreamAlias("aws-process-credentials-builder")
+@ComponentProfile(summary = "Credentials provider that can load credentials from an external process")
+public class ProcessCredentialsBuilder implements AWSCredentialsProviderBuilder {
+
+  /**
+   * The command that should be executed to retrieve credentials including arguments
+   * <p>
+   * e.g. if you have a custom aws credentials program that takes arguments then you could have
+   * {@code /opt/bin/awscreds-custom --username interlok} here. The program is expected to output JSON
+   * data as per the <a href=
+   * "https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes">documentation</a>
+   * </p>
+   */
+  @Getter
+  @Setter
+  @NotBlank
+  @NonNull
+  private String command;
+
+
+  /**
+   * The maximum amount of data that can be returned by the external process before an exception is
+   * raised.
+   * <p>
+   * If not specified, then the AWS internal default is used (currently 1024 bytes).
+   * </p>
+   */
+  @AdvancedConfig
+  @InputFieldDefault(value = "null")
+  @Getter
+  @Setter
+  private Long processOutputLimitBytes;
+
+  /**
+   * The number of seconds between when the credentials expire and when the credentials should start
+   * to be refreshed.
+   * 
+   * <p>
+   * This setting allows the credentials to be refreshed <strong>before</strong> they are reported to
+   * expire. If not configured, then the AWS internal default is used (currently 15 seconds)
+   * </p>
+   */
+  @AdvancedConfig
+  @InputFieldDefault(value = "null")
+  @Getter
+  @Setter
+  private Integer expirationBufferSeconds;
+
+  public ProcessCredentialsBuilder() {
+  }
+
+  @Override
+  public AWSCredentialsProvider build() throws Exception {
+    Builder builder = ProcessCredentialsProvider.builder().withCommand(getCommand());
+    if (getProcessOutputLimitBytes() != null) {
+      builder.withProcessOutputLimit(getProcessOutputLimitBytes().longValue());
+    }
+    if (getExpirationBufferSeconds() != null) {
+      builder.withCredentialExpirationBuffer(getExpirationBufferSeconds().intValue(), TimeUnit.SECONDS);
+    }
+    return builder.build();
+  }
+
+
+  public ProcessCredentialsBuilder withCommand(String s) {
+    setCommand(s);
+    return this;
+  }
+
+  public ProcessCredentialsBuilder withProcessOutputLimitBytes(Long l) {
+    setProcessOutputLimitBytes(l);
+    return this;
+  }
+
+  public ProcessCredentialsBuilder withExpirationBufferSeconds(Integer i) {
+    setExpirationBufferSeconds(i);
+    return this;
+  }
+
+}

--- a/interlok-aws-common/src/main/java/com/adaptris/aws/ProfileCredentialsBuilder.java
+++ b/interlok-aws-common/src/main/java/com/adaptris/aws/ProfileCredentialsBuilder.java
@@ -16,7 +16,8 @@ import lombok.Setter;
  * @config aws-profile-credentials-builder
  */
 @XStreamAlias("aws-profile-credentials-builder")
-@ComponentProfile(summary = "Credentials provider based on AWS configuration profiles")
+@ComponentProfile(summary = "Credentials provider based on AWS configuration profiles",
+    since = "3.9.2")
 public class ProfileCredentialsBuilder implements AWSCredentialsProviderBuilder {
 
   /**

--- a/interlok-aws-common/src/main/java/com/adaptris/aws/ProfileCredentialsBuilder.java
+++ b/interlok-aws-common/src/main/java/com/adaptris/aws/ProfileCredentialsBuilder.java
@@ -1,0 +1,91 @@
+package com.adaptris.aws;
+
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.InputFieldDefault;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.auth.profile.ProfilesConfigFile;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Credentials provider based on AWS configuration profiles
+ * 
+ * @config aws-profile-credentials-builder
+ */
+@XStreamAlias("aws-profile-credentials-builder")
+@ComponentProfile(summary = "Credentials provider based on AWS configuration profiles")
+public class ProfileCredentialsBuilder implements AWSCredentialsProviderBuilder {
+
+  /**
+   * The profile configuration file.
+   * <p>
+   * If not specified then the behaviour is down to the AWS SDK. This probably means that
+   * {@code ~/.aws/config} is used as the configuration file.
+   * </p>
+   */
+  @InputFieldDefault(value = "null")
+  @Getter
+  @Setter
+  private String configFile;
+
+  /**
+   * The profile within configuration.
+   * <p>
+   * If not specified then the behaviour is down to the AWS SDK. This will probably mean the default
+   * profile.
+   * </p>
+   */
+  @InputFieldDefault(value = "null")
+  @Getter
+  @Setter
+  private String profileName;
+
+  /**
+   * The refresh interval in nano seconds.
+   * <p>
+   * This maps onto {@code ProfileCredentialsProvider#setRefreshIntervalNanos(long}}. The
+   * corresponding {@code ProfileCredentialsProvider#setRefreshForceIntervalNanos(long)} is set to 2x
+   * whatever you have configured here.
+   * </p>
+   */
+  @AdvancedConfig
+  @InputFieldDefault(value = "null")
+  @Getter
+  @Setter
+  private Long refreshIntervalNanos;
+
+  public ProfileCredentialsBuilder() {
+  }
+
+  @Override
+  public AWSCredentialsProvider build() throws Exception {
+    ProfileCredentialsProvider credentials = new ProfileCredentialsProvider(configFile(), getProfileName());
+    if (getRefreshIntervalNanos() != null) {
+      credentials.setRefreshIntervalNanos(getRefreshIntervalNanos().longValue());
+      credentials.setRefreshForceIntervalNanos(getRefreshIntervalNanos().longValue() * 2);
+    }
+    return credentials;
+  }
+
+  private ProfilesConfigFile configFile() {
+    return getConfigFile() != null ? new ProfilesConfigFile(getConfigFile()) : null;
+  }
+
+  public ProfileCredentialsBuilder withConfigFile(String s) {
+    setConfigFile(s);
+    return this;
+  }
+
+  public ProfileCredentialsBuilder withProfileName(String s) {
+    setProfileName(s);
+    return this;
+  }
+
+  public ProfileCredentialsBuilder withRefreshIntervalNanos(Long l) {
+    setRefreshIntervalNanos(l);
+    return this;
+  }
+}

--- a/interlok-aws-common/src/main/java/com/adaptris/aws/PropertiesFileCredentialsBuilder.java
+++ b/interlok-aws-common/src/main/java/com/adaptris/aws/PropertiesFileCredentialsBuilder.java
@@ -1,0 +1,73 @@
+package com.adaptris.aws;
+
+import java.io.File;
+import org.apache.commons.lang3.BooleanUtils;
+import org.hibernate.validator.constraints.NotBlank;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.core.util.Args;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.ClasspathPropertiesFileCredentialsProvider;
+import com.amazonaws.auth.PropertiesFileCredentialsProvider;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+
+/**
+ * Credentials provider that loads credentials from a property file either from the filesystem or
+ * classpath.
+ * 
+ * <p>
+ * This class uses either {@code com.amazonaws.auth.PropertiesFileCredentialsProvider} or
+ * {@code com.amazonaws.auth.ClasspathPropertiesFileCredentialsProvider} depending on whether the
+ * specified file exists or not; if the file exists then we use
+ * {@code PropertiesFileCredentialsProvider} otherwise it is assumed to be on the classpath and we
+ * use {@code ClasspathPropertiesFileCredentialsProvider}.
+ * </p>
+ * 
+ * <p>
+ * The documentation for those two classes should be considered canonical, but essentially the AWS
+ * access key ID is expected to be in the <code>accessKey</code> property and the AWS secret key is
+ * expected to be in the <code>secretKey</code> property.
+ * </p>
+ * 
+ * @config aws-properties-file-credentials-builder
+ * 
+ */
+@XStreamAlias("aws-properties-file-credentials-builder")
+@ComponentProfile(
+    summary = "Credentials provider that loads credentials from a property file either from the filesystem or classpath")
+public class PropertiesFileCredentialsBuilder implements AWSCredentialsProviderBuilder {
+
+  /**
+   * The property file that contains the credentials
+   */
+  @Getter
+  @Setter
+  @NotBlank
+  @NonNull
+  private String propertyFile;
+
+  public PropertiesFileCredentialsBuilder() {
+  }
+
+  @Override
+  public AWSCredentialsProvider build() throws Exception {
+    File file = new File(Args.notBlank(getPropertyFile(), "property-file"));
+    if (isReadable(file)) {
+      return new PropertiesFileCredentialsProvider(file.getCanonicalPath());
+    }
+    return new ClasspathPropertiesFileCredentialsProvider(getPropertyFile());
+  }
+
+
+  private boolean isReadable(File f) {
+    return BooleanUtils.and(new boolean[] {f.exists(), f.isFile(), f.canRead()});
+  }
+
+  public PropertiesFileCredentialsBuilder withPropertyFile(String s) {
+    setPropertyFile(s);
+    return this;
+  }
+
+}

--- a/interlok-aws-common/src/main/java/com/adaptris/aws/PropertiesFileCredentialsBuilder.java
+++ b/interlok-aws-common/src/main/java/com/adaptris/aws/PropertiesFileCredentialsBuilder.java
@@ -36,7 +36,8 @@ import lombok.Setter;
  */
 @XStreamAlias("aws-properties-file-credentials-builder")
 @ComponentProfile(
-    summary = "Credentials provider that loads credentials from a property file either from the filesystem or classpath")
+    summary = "Credentials provider that loads credentials from a property file either from the filesystem or classpath",
+    since = "3.9.2")
 public class PropertiesFileCredentialsBuilder implements AWSCredentialsProviderBuilder {
 
   /**

--- a/interlok-aws-common/src/main/java/com/adaptris/aws/StaticCredentialsBuilder.java
+++ b/interlok-aws-common/src/main/java/com/adaptris/aws/StaticCredentialsBuilder.java
@@ -14,6 +14,8 @@ import lombok.NonNull;
 import lombok.Setter;
 
 /**
+ * A static set of credentials for AWS.
+ * 
  * @config aws-static-credentials-builder
  */
 @XStreamAlias("aws-static-credentials-builder")

--- a/interlok-aws-common/src/main/java/com/adaptris/aws/StaticCredentialsBuilder.java
+++ b/interlok-aws-common/src/main/java/com/adaptris/aws/StaticCredentialsBuilder.java
@@ -19,7 +19,7 @@ import lombok.Setter;
  * @config aws-static-credentials-builder
  */
 @XStreamAlias("aws-static-credentials-builder")
-@ComponentProfile(summary = "Create a static set of credentials")
+@ComponentProfile(summary = "Create a static set of credentials", since = "3.9.1")
 public class StaticCredentialsBuilder implements AWSCredentialsProviderBuilder {
 
   @NotNull

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/ProcessCredentialsBuilderTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/ProcessCredentialsBuilderTest.java
@@ -1,0 +1,25 @@
+package com.adaptris.aws;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.ProcessCredentialsProvider;
+
+public class ProcessCredentialsBuilderTest {
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBuild_Defaults() throws Exception {
+    ProcessCredentialsBuilder auth = new ProcessCredentialsBuilder();
+    AWSCredentialsProvider provider = auth.build();
+  }
+
+  @Test
+  public void testBuild() throws Exception {
+    ProcessCredentialsBuilder auth =
+        new ProcessCredentialsBuilder().withCommand("ls").withExpirationBufferSeconds(15).withProcessOutputLimitBytes(1024l);
+    AWSCredentialsProvider provider = auth.build();
+    assertNotNull(provider);
+    assertEquals(ProcessCredentialsProvider.class, provider.getClass());
+  }
+}

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/ProfileCredentialsBuilderTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/ProfileCredentialsBuilderTest.java
@@ -1,0 +1,45 @@
+package com.adaptris.aws;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.PrintStream;
+import org.junit.Test;
+import com.adaptris.core.stubs.TempFileUtils;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+
+public class ProfileCredentialsBuilderTest {
+
+  @Test
+  public void testBuild_Defaults() throws Exception {
+    ProfileCredentialsBuilder auth = new ProfileCredentialsBuilder();
+    AWSCredentialsProvider provider = auth.build();
+    assertNotNull(provider);
+    assertEquals(ProfileCredentialsProvider.class, provider.getClass());
+  }
+
+  @Test
+  public void testBuild_Profile() throws Exception {
+    ProfileCredentialsBuilder auth = new ProfileCredentialsBuilder();
+    File configFile = createCredentials(auth);
+    auth.withConfigFile(configFile.getCanonicalPath())
+        .withProfileName("external").withRefreshIntervalNanos(5L * 60 * 1000 * 1000);
+    AWSCredentialsProvider provider = auth.build();
+    assertNotNull(provider);
+    assertEquals(ProfileCredentialsProvider.class, provider.getClass());
+  }
+
+  private static File createCredentials(Object tracker) throws Exception {
+    File result = TempFileUtils.createTrackedFile(tracker);
+    try (PrintStream pw = new PrintStream(new FileOutputStream(result))) {
+      pw.println("[default]");
+      pw.println("aws_access_key_id = aws_access_key");
+      pw.println("aws_secret_access_key = aws_secret_key");
+      pw.println("[profile external]");
+      pw.println("credential_process = /opt/bin/awscreds-custom");
+    }
+    return result;
+  }
+}

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/PropertiesFileCredentialsBuilderTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/PropertiesFileCredentialsBuilderTest.java
@@ -1,0 +1,51 @@
+package com.adaptris.aws;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.PrintStream;
+import org.junit.Test;
+import com.adaptris.core.stubs.TempFileUtils;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.ClasspathPropertiesFileCredentialsProvider;
+import com.amazonaws.auth.PropertiesFileCredentialsProvider;
+
+public class PropertiesFileCredentialsBuilderTest {
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testBuild_Defaults() throws Exception {
+    PropertiesFileCredentialsBuilder auth = new PropertiesFileCredentialsBuilder();
+    AWSCredentialsProvider provider = auth.build();
+  }
+
+  @Test
+  public void testBuild_File() throws Exception {
+    PropertiesFileCredentialsBuilder auth =
+        new PropertiesFileCredentialsBuilder();
+    File file = createCredentials(auth);
+    auth.withPropertyFile(file.getCanonicalPath());
+    AWSCredentialsProvider provider = auth.build();
+    assertNotNull(provider);
+    assertEquals(PropertiesFileCredentialsProvider.class, provider.getClass());
+  }
+
+  @Test
+  public void testBuild_Classpath() throws Exception {
+    PropertiesFileCredentialsBuilder auth = new PropertiesFileCredentialsBuilder().withPropertyFile("classpath-credentials.properties");
+    AWSCredentialsProvider provider = auth.build();
+    assertNotNull(provider);
+    assertEquals(ClasspathPropertiesFileCredentialsProvider.class, provider.getClass());
+  }
+
+  private static File createCredentials(Object tracker) throws Exception {
+    File result = TempFileUtils.createTrackedFile(tracker);
+    try (PrintStream pw = new PrintStream(new FileOutputStream(result))) {
+      pw.println("accessKey=MyAccessKey");
+      pw.println("secretKey=MySecretKey");
+      pw.println("other=properties");
+      pw.println("that=are_ignored");
+    }
+    return result;
+  }
+}

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/StaticCredentialsBuilderTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/StaticCredentialsBuilderTest.java
@@ -3,9 +3,7 @@ package com.adaptris.aws;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
-
 import org.junit.Test;
-
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;

--- a/interlok-aws-common/src/test/resources/classpath-credentials.properties
+++ b/interlok-aws-common/src/test/resources/classpath-credentials.properties
@@ -1,0 +1,2 @@
+accessKey=MyAccessKey
+secretKey=MySecretKey


### PR DESCRIPTION
- Fix javadocs for link.
- Add a ProcessCredentialsProvider builder; anticipate using this for hashicorp
- Add a ProfileCredentialsProvider builder; we could use use this for hashicorp if we use the credential_process functionality
- Add a PropertiesFileCredentials thing that proxies the properties file from either the classpath or from the filesystem.