### PR TITLE
INTERLOK-2860 Feature parity with jclouds-blobstore

### DIFF
--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/GetTagOperation.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/GetTagOperation.java
@@ -33,7 +33,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * Get tags associated with a S3 Object
  * 
  * <p>
- * Uses {@link AmazonS3Client#getObjectTagging#(GetObjectTaggingRequest)}
+ * Uses {@code AmazonS3Client#getObjectTagging(GetObjectTaggingRequest)}
  * </p>
  * 
  * @config amazon-s3-tag-get

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/ListOperation.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/ListOperation.java
@@ -20,11 +20,15 @@ import java.util.ArrayList;
 import java.util.Collection;
 import org.apache.commons.lang3.ObjectUtils;
 import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.interlok.cloud.BlobListRenderer;
 import com.adaptris.interlok.cloud.RemoteBlob;
+import com.adaptris.interlok.cloud.RemoteBlobFilter;
 import com.adaptris.interlok.config.DataInputParameter;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectListing;
@@ -42,12 +46,24 @@ import lombok.Setter;
 @ComponentProfile(summary = "List of files based on S3 key",
     since = "3.9.1")
 @XStreamAlias("amazon-s3-list")
-@DisplayOrder(order ={ "bucketName", "key", "filterSuffix"})
+@DisplayOrder(order = {"bucketName", "key", "filter", "filterSuffix"})
 public class ListOperation extends S3OperationImpl {
+  private transient boolean warningLogged;
 
   @Getter
   @Setter
+  @Deprecated
+  @Removal(version = "3.11.0", message = "Use a RemoteBlobFilter instead")
   private DataInputParameter<String> filterSuffix;
+
+  /**
+   * Specify any additional filtering you wish to perform on the list.
+   * 
+   */
+  @AdvancedConfig
+  @Getter
+  @Setter
+  private RemoteBlobFilter filter;
 
   /**
    * Specify the output style.
@@ -76,21 +92,20 @@ public class ListOperation extends S3OperationImpl {
 
   private Collection<RemoteBlob> filter(ObjectListing listing, AdaptrisMessage msg) throws Exception {
     Collection<RemoteBlob> list = new ArrayList<>();
-    String filterSuffix = "";
-    if (getFilterSuffix() != null) {
-      filterSuffix = getFilterSuffix().extract(msg);
-    }
+    RemoteBlobFilter filterToUse = blobFilter(msg);
     for (S3ObjectSummary summary : listing.getObjectSummaries()) {
-      if (summary.getKey().endsWith(filterSuffix)) {
-        list.add(new RemoteBlob.Builder().setBucket(summary.getBucketName()).setLastModified(summary.getLastModified().getTime())
-            .setName(summary.getKey()).setSize(summary.getSize()).build()
-        );
+      RemoteBlob blob = new RemoteBlob.Builder().setBucket(summary.getBucketName()).setLastModified(summary.getLastModified().getTime())
+          .setName(summary.getKey()).setSize(summary.getSize()).build();
+      if (filterToUse.accept(blob)) {
+        list.add(blob);
       }
     }
     return list;
   }
 
 
+  @Deprecated
+  @Removal(version = "3.11.0")
   public ListOperation withFilterSuffix(DataInputParameter<String> key) {
     setFilterSuffix(key);
     return this;
@@ -98,6 +113,28 @@ public class ListOperation extends S3OperationImpl {
 
   private BlobListRenderer outputStyle() {
     return ObjectUtils.defaultIfNull(getOutputStyle(), new BlobListRenderer() {});
+  }
+
+  public ListOperation withOutputStyle(BlobListRenderer render) {
+    setOutputStyle(render);
+    return this;
+  }
+
+
+  public ListOperation withFilter(RemoteBlobFilter filter) {
+    setFilter(filter);
+    return this;
+  }
+
+  private RemoteBlobFilter blobFilter(AdaptrisMessage msg) throws Exception {
+    if (getFilterSuffix() != null) {
+      LoggingHelper.logWarning(warningLogged, () -> {
+        warningLogged = true;
+      }, "Use of filter-suffix is deprecated; use a filter instead");
+      final String suffix = getFilterSuffix().extract(msg);
+      return (blob) -> blob.getName().endsWith(suffix);
+    }
+    return ObjectUtils.defaultIfNull(getFilter(), (blob) -> true);
   }
 
 }

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3BucketList.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3BucketList.java
@@ -1,0 +1,132 @@
+package com.adaptris.aws.s3;
+
+import javax.validation.constraints.NotBlank;
+import org.apache.commons.lang3.StringUtils;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.core.AdaptrisConnection;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ConnectedService;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.DynamicPollingTemplate;
+import com.adaptris.core.ServiceException;
+import com.adaptris.core.ServiceImp;
+import com.adaptris.core.common.ConstantDataInputParameter;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.interlok.cloud.BlobListRenderer;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+
+/**
+ * Poll an S3 Location for a list of files.
+ * <p>
+ * This is intended for use as part of a {@link DynamicPollingTemplate}; as a result things will not
+ * be resolved using the expression language, the bucket and key must be explicitly configured.
+ * Under the covers it re-uses {@link S3Service} with a {@link ListOperation} and does a full
+ * lifecycle on the service each time it is triggered.
+ * </p>
+ * 
+ * @config s3-bucket-list
+ */
+@XStreamAlias("s3-bucket-list")
+@ComponentProfile(summary = "List contents of an S3 bucket as part of a polling-trigger", since = "3.9.2", tag = "aws,s3,polling")
+public class S3BucketList extends ServiceImp implements DynamicPollingTemplate.TemplateProvider, ConnectedService {
+
+  @Setter
+  @Getter
+  private AdaptrisConnection connection;
+
+  @Setter
+  @Getter
+  private BlobListRenderer outputStyle;
+
+  /**
+   * The S3 bucket to connect to.
+   * 
+   */
+  @NotBlank
+  @Setter
+  @Getter
+  @NonNull
+  private String bucket;
+
+  /**
+   * The S3 key to perform a list operation on.
+   * 
+   */
+  @NotBlank
+  @Setter
+  @Getter
+  @NonNull
+  private String key;
+
+  /**
+   * A simplified filter based on the suffix of the blob.
+   * 
+   */
+  @Getter
+  @Setter
+  private String filterSuffix;
+
+  @Override
+  public void prepare() throws CoreException {}
+
+  @Override
+  protected void initService() throws CoreException {}
+
+  @Override
+  protected void closeService() {}
+
+  @Override
+  public void doService(AdaptrisMessage msg) throws ServiceException {
+    S3Service service = buildService(); 
+    try {
+      LifecycleHelper.initAndStart(service, false);
+      service.doService(msg);
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapServiceException(e);
+    } finally {
+      LifecycleHelper.stopAndClose(service, false);
+    }
+  }
+
+  public S3BucketList withConnection(AdaptrisConnection c) {
+    setConnection(c);
+    return this;
+  }
+
+  public S3BucketList withKey(String key) {
+    setKey(key);
+    return this;
+  }
+
+  public S3BucketList withBucket(String bucket) {
+    setBucket(bucket);
+    return this;
+  }
+
+  public S3BucketList withFilterSuffix(String suffix) {
+    setFilterSuffix(suffix);
+    return this;
+  }
+
+
+  public S3BucketList withOutputStyle(BlobListRenderer outputStyle) {
+    setOutputStyle(outputStyle);
+    return this;
+  }
+
+  private S3Service buildService() {
+    ListOperation op = new ListOperation()
+        .withBucketName(new ConstantDataInputParameter(getBucket()))
+        .withKey(new ConstantDataInputParameter(getKey()));
+    op.setOutputStyle(getOutputStyle());
+    if (!StringUtils.isBlank(getFilterSuffix())) {
+      op.setFilterSuffix(new ConstantDataInputParameter(getFilterSuffix()));
+    }
+    return new S3Service(getConnection(), op);
+  }
+
+}

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3Service.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3Service.java
@@ -18,7 +18,6 @@ package com.adaptris.aws.s3;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
@@ -28,7 +27,6 @@ import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
-import com.adaptris.interlok.InterlokException;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
@@ -57,7 +55,7 @@ public class S3Service extends S3ServiceImpl {
   @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
     try {
-      getOperation().execute(getConnection().retrieveConnection(AmazonS3Connection.class), msg);
+      getOperation().execute(getConnection().retrieveConnection(ClientWrapper.class), msg);
     } catch (Exception e) {
       throw ExceptionHelper.wrapServiceException(e);
     }

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3ServiceImpl.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3ServiceImpl.java
@@ -17,43 +17,20 @@
 package com.adaptris.aws.s3;
 
 import javax.validation.Valid;
-
 import com.adaptris.core.AdaptrisConnection;
 import com.adaptris.core.ConnectedService;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceImp;
 import com.adaptris.core.util.LifecycleHelper;
-import com.amazonaws.ClientConfiguration;
 
 /**
  * Abstract implemention of {@link S3Service}
- * <p>
- * This class directly exposes almost all the getter and setters that are available in {@link ClientConfiguration} via the
- * {@link #getClientConfiguration()} property for maximum flexibility in configuration.
- * </p>
- * <p>
- * The key from the <code>client-configuration</code> element should match the name of the underlying ClientConfiguration
- * property; so if you wanted to control the user-agent you would do :
- * </p>
- * <pre>
- * {@code 
- *   <client-configuration>
- *     <key-value-pair>
- *        <key>UserAgent</key>
- *        <value>My User Agent</value>
- *     </key-value-pair>
- *   </client-configuration>
- * }
- * </pre>
  * 
- * @author lchan
- *
  */
 public abstract class S3ServiceImpl extends ServiceImp implements ConnectedService {
 
   @Valid
   private AdaptrisConnection connection;
-  private transient boolean warningLogged;
   
   public S3ServiceImpl() {
   }

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/BucketListTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/BucketListTest.java
@@ -1,0 +1,89 @@
+package com.adaptris.aws.s3;
+
+import static com.adaptris.aws.s3.MockedOperationTest.createSummary;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+import org.mockito.Mockito;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.ServiceCase;
+import com.adaptris.core.ServiceException;
+import com.adaptris.interlok.cloud.BlobListRenderer;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+
+public class BucketListTest {
+
+  @Test
+  public void testService_NoFilter() throws Exception {
+    AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
+    AmazonS3Connection mockConnection = Mockito.mock(AmazonS3Connection.class);
+    ClientWrapper wrapper = new ClientWrapperImpl(client);
+    Mockito.when(mockConnection.retrieveConnection(any())).thenReturn(wrapper);
+
+    ObjectListing listing = Mockito.mock(ObjectListing.class);
+    List<S3ObjectSummary> summaries = new ArrayList<>(Arrays.asList(createSummary("srcBucket", "srcKeyPrefix/"),
+        createSummary("srcBucket", "srcKeyPrefix/file.json"), createSummary("srcBucket", "srcKeyPrefix/file2.csv")));
+    Mockito.when(listing.getObjectSummaries()).thenReturn(summaries);
+    Mockito.when(client.listObjects(anyString(), anyString())).thenReturn(listing);
+
+    S3BucketList bucket =
+        new S3BucketList().withConnection(mockConnection).withBucket("srcBucket").withKey("srcKeyPrefix").withOutputStyle(null);
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    ServiceCase.execute(bucket, msg);
+    List<String> lines = IOUtils.readLines(new StringReader(msg.getContent()));
+    assertEquals(3, lines.size());
+  }
+
+  @Test
+  public void testService_Filter() throws Exception {
+    AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
+    AmazonS3Connection mockConnection = Mockito.mock(AmazonS3Connection.class);
+    ClientWrapper wrapper = new ClientWrapperImpl(client);
+    Mockito.when(mockConnection.retrieveConnection(any())).thenReturn(wrapper);
+
+    ObjectListing listing = Mockito.mock(ObjectListing.class);
+    List<S3ObjectSummary> summaries = new ArrayList<>(Arrays.asList(createSummary("srcBucket", "srcKeyPrefix/"),
+        createSummary("srcBucket", "srcKeyPrefix/file.json"), createSummary("srcBucket", "srcKeyPrefix/file2.csv")));
+    Mockito.when(listing.getObjectSummaries()).thenReturn(summaries);
+    Mockito.when(client.listObjects(anyString(), anyString())).thenReturn(listing);
+
+    S3BucketList bucket =
+        new S3BucketList().withConnection(mockConnection).withBucket("srcBucket").withKey("srcKeyPrefix").withFilterSuffix(".json");
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    ServiceCase.execute(bucket, msg);
+    List<String> lines = IOUtils.readLines(new StringReader(msg.getContent()));
+    assertEquals(1, lines.size());
+  }
+
+  @Test(expected = ServiceException.class)
+  public void testService_Failure() throws Exception {
+    AmazonS3Connection mockConnection = Mockito.mock(AmazonS3Connection.class);
+    AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
+    ClientWrapper wrapper = new ClientWrapperImpl(client);
+    Mockito.when(mockConnection.retrieveConnection(any())).thenReturn(wrapper);
+    BlobListRenderer brokenRender = Mockito.mock(BlobListRenderer.class);
+    Mockito.doThrow(new RuntimeException()).when(brokenRender).render(any(), any());
+    S3BucketList bucket =
+        new S3BucketList().withConnection(mockConnection).withBucket("srcBucket").withKey("srcKeyPrefix")
+            .withOutputStyle(brokenRender);
+
+    ObjectListing listing = Mockito.mock(ObjectListing.class);
+    List<S3ObjectSummary> summaries = new ArrayList<>(Arrays.asList(createSummary("srcBucket", "srcKeyPrefix/"),
+        createSummary("srcBucket", "srcKeyPrefix/file.json"), createSummary("srcBucket", "srcKeyPrefix/file2.csv")));
+    Mockito.when(listing.getObjectSummaries()).thenReturn(summaries);
+    Mockito.when(client.listObjects(anyString(), anyString())).thenReturn(listing);
+
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    ServiceCase.execute(bucket, msg);
+  }
+
+}

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/BucketListTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/BucketListTest.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.junit.Test;
 import org.mockito.Mockito;
 import com.adaptris.core.AdaptrisMessage;
@@ -16,6 +17,7 @@ import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ServiceCase;
 import com.adaptris.core.ServiceException;
 import com.adaptris.interlok.cloud.BlobListRenderer;
+import com.adaptris.interlok.cloud.RemoteBlobFilterWrapper;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
@@ -55,9 +57,11 @@ public class BucketListTest {
         createSummary("srcBucket", "srcKeyPrefix/file.json"), createSummary("srcBucket", "srcKeyPrefix/file2.csv")));
     Mockito.when(listing.getObjectSummaries()).thenReturn(summaries);
     Mockito.when(client.listObjects(anyString(), anyString())).thenReturn(listing);
+    RemoteBlobFilterWrapper filter =
+        new RemoteBlobFilterWrapper().withFilterExpression(".*\\.json").withFilterImp(RegexFileFilter.class.getCanonicalName());
 
     S3BucketList bucket =
-        new S3BucketList().withConnection(mockConnection).withBucket("srcBucket").withKey("srcKeyPrefix").withFilterSuffix(".json");
+        new S3BucketList().withConnection(mockConnection).withBucket("srcBucket").withKey("srcKeyPrefix").withFilter(filter);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     ServiceCase.execute(bucket, msg);
     List<String> lines = IOUtils.readLines(new StringReader(msg.getContent()));

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/MockedOperationTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/MockedOperationTest.java
@@ -14,6 +14,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.junit.Test;
 import org.mockito.Mockito;
 import com.adaptris.aws.s3.meta.S3ServerSideEncryption;
@@ -22,6 +23,7 @@ import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.common.ConstantDataInputParameter;
 import com.adaptris.core.lms.FileBackedMessageFactory;
 import com.adaptris.core.metadata.NoOpMetadataFilter;
+import com.adaptris.interlok.cloud.RemoteBlobFilterWrapper;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CopyObjectResult;
 import com.amazonaws.services.s3.model.GetObjectRequest;
@@ -300,7 +302,7 @@ public class MockedOperationTest {
 
 
   @Test
-  public void testListOperationFilter() throws Exception {
+  public void testListOperation_LegacyFilter() throws Exception {
     AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
     TransferManager transferManager = Mockito.mock(TransferManager.class);
     ObjectListing result = Mockito.mock(ObjectListing.class);
@@ -313,6 +315,29 @@ public class MockedOperationTest {
     Mockito.when(client.listObjects(anyString(), anyString())).thenReturn(result);
     ListOperation ls = new ListOperation()
         .withFilterSuffix(new ConstantDataInputParameter(".json"))
+        .withBucketName(new ConstantDataInputParameter("srcBucket")).withKey(new ConstantDataInputParameter("srcKeyPrefix/"));
+
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("");
+    ClientWrapper wrapper = new ClientWrapperImpl(client, transferManager);
+    ls.execute(wrapper, msg);
+    assertEquals("srcKeyPrefix/file.json" + System.lineSeparator(), msg.getContent());
+  }
+
+  @Test
+  public void testListOperation_RemoteBlobFilter() throws Exception {
+    AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
+    TransferManager transferManager = Mockito.mock(TransferManager.class);
+    ObjectListing result = Mockito.mock(ObjectListing.class);
+    S3ObjectSummary sbase = createSummary("srcBucket", "srcKeyPrefix/");
+    S3ObjectSummary s1 = createSummary("srcBucket", "srcKeyPrefix/file.json");
+    S3ObjectSummary s2 = createSummary("srcBucket", "srcKeyPrefix/file2.csv");
+
+    List<S3ObjectSummary> list = new ArrayList<>(Arrays.asList(sbase, s1, s2));
+    Mockito.when(result.getObjectSummaries()).thenReturn(list);
+    Mockito.when(client.listObjects(anyString(), anyString())).thenReturn(result);
+    RemoteBlobFilterWrapper filter =
+        new RemoteBlobFilterWrapper().withFilterExpression(".*\\.json").withFilterImp(RegexFileFilter.class.getCanonicalName());
+    ListOperation ls = new ListOperation().withFilter(filter)
         .withBucketName(new ConstantDataInputParameter("srcBucket")).withKey(new ConstantDataInputParameter("srcKeyPrefix/"));
 
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("");

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/MockedOperationTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/MockedOperationTest.java
@@ -321,7 +321,7 @@ public class MockedOperationTest {
     assertEquals("srcKeyPrefix/file.json" + System.lineSeparator(), msg.getContent());
   }
 
-  private S3ObjectSummary createSummary(String bucket, String key) {
+  public static S3ObjectSummary createSummary(String bucket, String key) {
     S3ObjectSummary sbase = new S3ObjectSummary();
     sbase.setBucketName(bucket);
     sbase.setKey(key);

--- a/interlok-aws-s3/src/test/resources/unit-tests.properties.template
+++ b/interlok-aws-s3/src/test/resources/unit-tests.properties.template
@@ -10,3 +10,4 @@ junit.localstack.s3.upload.filename=hello-world.txt
 junit.localstack.s3.copy.filename=goodbye.txt
 junit.localstack.s3.tmp.dir=@BUILD_DIR@/tmp
 junit.localstack.s3.ls.filterSuffix=.txt
+junit.localstack.s3.ls.filterRegexp=.*\\.txt


### PR DESCRIPTION
- ListOperation now uses RemoteBlobFilter - introduced in 3.9-SNAPSHOT(2019-10-09)
- ListOperation#filterSuffix is now deprecated
- s3-bucket-list now provides a dynamic-polling-template provider so you can configure it as part of a polling-trigger if this is your bag.
