### PR TITLE
INTERLOK-3059 if secret+access key are blank, then return null

### DIFF
--- a/interlok-aws-common/src/main/java/com/adaptris/aws/AWSAuthentication.java
+++ b/interlok-aws-common/src/main/java/com/adaptris/aws/AWSAuthentication.java
@@ -16,12 +16,11 @@
 
 package com.adaptris.aws;
 
-import com.adaptris.security.exc.AdaptrisSecurityException;
 import com.amazonaws.auth.AWSCredentials;
 
 @FunctionalInterface
 public interface AWSAuthentication {
     
-  public AWSCredentials getAWSCredentials() throws AdaptrisSecurityException;
+  public AWSCredentials getAWSCredentials() throws Exception;
   
 }

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/AwsKeysAuthenticationTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/AwsKeysAuthenticationTest.java
@@ -1,13 +1,16 @@
 package com.adaptris.aws;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import org.junit.Test;
 
 public class AwsKeysAuthenticationTest {
 
   @Test
   public void testAWSCredentials() throws Exception {
-    AWSKeysAuthentication auth = new AWSKeysAuthentication("accessKey", "secretKey");
-    assertNotNull(auth.getAWSCredentials());
+    assertNotNull(new AWSKeysAuthentication("accessKey", "secretKey").getAWSCredentials());
+    assertNotNull(new AWSKeysAuthentication("", "secretKey").getAWSCredentials());
+    assertNotNull(new AWSKeysAuthentication("accessKey", "").getAWSCredentials());
+    assertNull(new AWSKeysAuthentication().getAWSCredentials());
   }
 }


### PR DESCRIPTION
If secret + access are blank (or effectively null); then we just return null which causes the parent StaticCredentialsProvider to use a DefaultProviderChain

- Removed NotNull / NonNull annotations
