### PR TITLE
INTERLOK-3079 + INTERLOK-3176 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,8 +134,6 @@ subprojects {
       annotationProcessor ("com.adaptris:interlok-core-apt:$interlokCoreVersion") { changing= true}
       testCompile ('junit:junit:4.13')
       testCompile ("com.adaptris:interlok-stubs:$interlokCoreVersion") { changing= true}
-      testCompile ('log4j:log4j:1.2.17')
-      testCompile ("org.slf4j:slf4j-log4j12:$slf4jVersion")
       testCompile ("org.slf4j:jcl-over-slf4j:$slf4jVersion")
       testCompile ("org.apache.logging.log4j:log4j-core:${log4j2Version}")
       testCompile ("org.apache.logging.log4j:log4j-1.2-api:${log4j2Version}")

--- a/interlok-aws-sqs/src/main/java/com/adaptris/aws/sqs/AmazonSQSConsumer.java
+++ b/interlok-aws-sqs/src/main/java/com/adaptris/aws/sqs/AmazonSQSConsumer.java
@@ -21,9 +21,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
 import javax.management.MalformedObjectNameException;
+import org.apache.commons.lang3.BooleanUtils;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisComponent;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -45,6 +47,7 @@ import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.SneakyThrows;
 
 /**
  * <p>
@@ -77,9 +80,24 @@ public class AmazonSQSConsumer extends AdaptrisPollingConsumer {
   @Setter
   private String ownerAwsAccountId;
 
-  private transient AmazonSQS sqs;
-  private transient String queueUrl;
+  /**
+   * Whether or not to always delete the message from the queue.
+   * 
+   * <p>
+   * Since the workflow can be configured weith complex behaviour on errors, we have traditionally deleted the message once
+   * submitted to the workflow. In the specific AWS instance, this means that any configured 'Dead Letter Queue' behaviour will
+   * since AWS will consider the message to have been successfully delivered.
+   * </p>
+   * If set to false, then messages will be deleted once they are successfully processed. The default value is 'true' to preserve
+   * backwards compatible behaviour
+   * </p>
+   */
+  @Getter
+  @Setter
+  @InputFieldDefault(value = "true")
+  private Boolean alwaysDelete;
 
+  private transient String queueUrl = null;
   private transient List<String> receiveAttributes = Collections.singletonList("All");
   private transient List<String> receiveMessageAttributes = Collections.singletonList("All");
 
@@ -98,7 +116,6 @@ public class AmazonSQSConsumer extends AdaptrisPollingConsumer {
 
   @Override
   public void start() throws CoreException {
-    getSynClient();
     getQueueUrl();
     super.start();
   }
@@ -106,7 +123,7 @@ public class AmazonSQSConsumer extends AdaptrisPollingConsumer {
   @Override
   public void stop() {
     super.stop();
-    // sqs = null;
+    queueUrl = null;
   }
 
   /**
@@ -119,24 +136,25 @@ public class AmazonSQSConsumer extends AdaptrisPollingConsumer {
   @Override
   protected int processMessages() {
     int count = 0;
-
     try {
       List<Message> messages;
+      final String myQueueUrl = getQueueUrl();
 
       messageCountLoop:
       do{
-        ReceiveMessageRequest receiveMessageRequest = new ReceiveMessageRequest(queueUrl);
+        ReceiveMessageRequest receiveMessageRequest = new ReceiveMessageRequest(myQueueUrl);
         if(getPrefetchCount() != null) {
           receiveMessageRequest.setMaxNumberOfMessages(getPrefetchCount());
         }
         receiveMessageRequest.setAttributeNames(receiveAttributes);
         receiveMessageRequest.setMessageAttributeNames(receiveMessageAttributes);
-        messages = sqs.receiveMessage(receiveMessageRequest).getMessages();
+        messages = getSynClient().receiveMessage(receiveMessageRequest).getMessages();
         log.trace(messages.size() + " messages to process");
 
         for (Message message : messages) {
           try {
             AdaptrisMessage adpMsg = AdaptrisMessageFactory.defaultIfNull(getMessageFactory()).newMessage(message.getBody());
+            final String handle = message.getReceiptHandle();
             adpMsg.addMetadata("SQSMessageID", message.getMessageId());
             for (Entry<String, String> entry : message.getAttributes().entrySet()) {
               adpMsg.addMetadata(entry.getKey(), entry.getValue());
@@ -144,11 +162,14 @@ public class AmazonSQSConsumer extends AdaptrisPollingConsumer {
             for (Entry<String, MessageAttributeValue> entry : message.getMessageAttributes().entrySet()) {
               adpMsg.addMetadata(entry.getKey(), entry.getValue().getStringValue());
             }
-
-            retrieveAdaptrisMessageListener().onAdaptrisMessage(adpMsg);
-            //
-            sqs.deleteMessage(new DeleteMessageRequest(queueUrl, message.getReceiptHandle()));
-
+            if (alwaysDelete()) {
+              retrieveAdaptrisMessageListener().onAdaptrisMessage(adpMsg);
+              getSynClient().deleteMessage(new DeleteMessageRequest(myQueueUrl, handle));
+            } else {
+              retrieveAdaptrisMessageListener().onAdaptrisMessage(adpMsg, (m) -> {
+                getSynClient().deleteMessage(new DeleteMessageRequest(myQueueUrl, handle));
+              });
+            }
             if (!continueProcessingMessages(++count)) {
                 break messageCountLoop;
             }
@@ -176,11 +197,9 @@ public class AmazonSQSConsumer extends AdaptrisPollingConsumer {
     return Integer.parseInt(result.getAttributes().get(QueueAttributeName.ApproximateNumberOfMessages.toString()));
   }
 
-  private AmazonSQS getSynClient() throws CoreException {
-    if(sqs == null) {
-      sqs = retrieveConnection(AmazonSQSConnection.class).getSyncClient();
-    }
-    return sqs;
+  @SneakyThrows(CoreException.class)
+  private AmazonSQS getSynClient() {
+    return retrieveConnection(AmazonSQSConnection.class).getSyncClient();
   }
 
   private String getQueueUrl() throws CoreException {
@@ -188,6 +207,10 @@ public class AmazonSQSConsumer extends AdaptrisPollingConsumer {
       queueUrl = AwsHelper.buildQueueUrl(getDestination().getDestination(), getOwnerAwsAccountId(), getSynClient());
     }
     return queueUrl;
+  }
+
+  private boolean alwaysDelete() {
+    return BooleanUtils.toBooleanDefaultIfNull(getAlwaysDelete(), true);
   }
 
   private static class JmxFactory extends RuntimeInfoComponentFactory {

--- a/interlok-aws-sqs/src/main/java/com/adaptris/aws/sqs/AmazonSQSConsumer.java
+++ b/interlok-aws-sqs/src/main/java/com/adaptris/aws/sqs/AmazonSQSConsumer.java
@@ -21,8 +21,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
 import javax.management.MalformedObjectNameException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
@@ -40,7 +38,6 @@ import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.DeleteMessageRequest;
 import com.amazonaws.services.sqs.model.GetQueueAttributesRequest;
 import com.amazonaws.services.sqs.model.GetQueueAttributesResult;
-import com.amazonaws.services.sqs.model.GetQueueUrlRequest;
 import com.amazonaws.services.sqs.model.Message;
 import com.amazonaws.services.sqs.model.MessageAttributeValue;
 import com.amazonaws.services.sqs.model.QueueAttributeName;
@@ -80,7 +77,6 @@ public class AmazonSQSConsumer extends AdaptrisPollingConsumer {
   @Setter
   private String ownerAwsAccountId;
 
-  private transient Log log = LogFactory.getLog(this.getClass().getName());
   private transient AmazonSQS sqs;
   private transient String queueUrl;
 
@@ -188,12 +184,8 @@ public class AmazonSQSConsumer extends AdaptrisPollingConsumer {
   }
 
   private String getQueueUrl() throws CoreException {
-    if(queueUrl == null) {
-      GetQueueUrlRequest queueUrlRequest = new GetQueueUrlRequest(getDestination().getDestination());
-      if (!isEmpty(getOwnerAwsAccountId())) {
-        queueUrlRequest.withQueueOwnerAWSAccountId(getOwnerAwsAccountId());
-      }
-      queueUrl = getSynClient().getQueueUrl(queueUrlRequest).getQueueUrl();
+    if (queueUrl == null) {
+      queueUrl = AwsHelper.buildQueueUrl(getDestination().getDestination(), getOwnerAwsAccountId(), getSynClient());
     }
     return queueUrl;
   }

--- a/interlok-aws-sqs/src/main/java/com/adaptris/aws/sqs/AmazonSQSProducer.java
+++ b/interlok-aws-sqs/src/main/java/com/adaptris/aws/sqs/AmazonSQSProducer.java
@@ -43,7 +43,6 @@ import com.adaptris.util.TimeInterval;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.sqs.AmazonSQSAsync;
-import com.amazonaws.services.sqs.model.GetQueueUrlRequest;
 import com.amazonaws.services.sqs.model.MessageAttributeValue;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
 import com.amazonaws.services.sqs.model.SendMessageResult;
@@ -192,18 +191,10 @@ public class AmazonSQSProducer extends ProduceOnlyProducerImp {
     String queueURL = (String) cachedQueueURLs.get(queueName);
     // It's not in the cache. Look up the queue url from Amazon and cache it.
     if(queueURL == null) {
-      queueURL = retrieveQueueURLFromSQS(queueName);
+      queueURL = AwsHelper.buildQueueUrl(queueName, getOwnerAwsAccountId(), getSQS());
       cachedQueueURLs.put(queueName, queueURL);
     }
     return queueURL;
-  }
-  
-  private String retrieveQueueURLFromSQS(String queueName) throws AmazonServiceException, AmazonClientException, CoreException {
-    GetQueueUrlRequest getQueueUrlRequest = new GetQueueUrlRequest(queueName);
-    if (!StringUtils.isEmpty(getOwnerAwsAccountId())) {
-      getQueueUrlRequest.withQueueOwnerAWSAccountId(getOwnerAwsAccountId());
-    }
-    return getSQS().getQueueUrl(getQueueUrlRequest).getQueueUrl();
   }
 
   @Override

--- a/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/AwsConsumerTest.java
+++ b/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/AwsConsumerTest.java
@@ -21,21 +21,25 @@ import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.After;
+import java.util.Map.Entry;
+import java.util.function.Consumer;
 import org.junit.Before;
 import org.junit.Test;
 import com.adaptris.aws.AWSKeysAuthentication;
 import com.adaptris.aws.StaticCredentialsBuilder;
+import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConfiguredConsumeDestination;
 import com.adaptris.core.ConsumerCase;
 import com.adaptris.core.QuartzCronPoller;
 import com.adaptris.core.StandaloneConsumer;
+import com.adaptris.core.stubs.MessageCounter;
 import com.adaptris.core.stubs.MockMessageListener;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.util.GuidGenerator;
@@ -49,6 +53,7 @@ import com.amazonaws.services.sqs.model.GetQueueAttributesResult;
 import com.amazonaws.services.sqs.model.GetQueueUrlRequest;
 import com.amazonaws.services.sqs.model.GetQueueUrlResult;
 import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.MessageAttributeValue;
 import com.amazonaws.services.sqs.model.QueueAttributeName;
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
 import com.amazonaws.services.sqs.model.ReceiveMessageResult;
@@ -57,14 +62,8 @@ public class AwsConsumerTest extends ConsumerCase {
 
   private static final String payload = "The quick brown fox jumps over the lazy dog.";
   
-  private MockMessageListener messageListener;
-  
   private AmazonSQS sqsClientMock;
   private AmazonSQSConnection connectionMock;
-
-  private AmazonSQSConsumer sqsConsumer;
-
-  private StandaloneConsumer standaloneConsumer;
   
   @Override
   public boolean isAnnotatedForJunit4() {
@@ -84,51 +83,91 @@ public class AwsConsumerTest extends ConsumerCase {
     when(connectionMock.getSyncClient()).thenReturn(sqsClientMock);
   }
   
-  @After
-  public void tearDown() throws Exception {
-    LifecycleHelper.stopAndClose(sqsConsumer);
-  }
-  
   @Test
   public void testConsumerInitialisation() throws Exception {
-    startConsumer();
+    StandaloneConsumer consumer = startConsumer();
+    LifecycleHelper.stopAndClose(consumer);
   }
 
   @Test
   public void testWithoutQueueOwnerAWSAccountId() throws Exception {
-    startConsumer();
+    StandaloneConsumer consumer = startConsumer();
     verify(sqsClientMock, atLeast(1)).getQueueUrl(new GetQueueUrlRequest("queue"));
+    LifecycleHelper.stopAndClose(consumer);
   }
 
   @Test
   public void testWithQueueOwnerAWSAccountId() throws Exception {
-    startConsumerWithAccountID();
+    StandaloneConsumer consumer = startConsumerWithAccountID();
     GetQueueUrlRequest getQueueUrlRequest = new GetQueueUrlRequest("queue");
     getQueueUrlRequest.withQueueOwnerAWSAccountId("accountId");
     verify(sqsClientMock, atLeast(1)).getQueueUrl(getQueueUrlRequest);
+    LifecycleHelper.stopAndClose(consumer);
   }
   
   @Test
-  public void testSingleConsume() throws Exception {
+  public void testSingleConsume_AlwaysDelete() throws Exception {
+    // Return the ReceiveMessageResult with 1 message the first call, an empty result the second and all subsequent calls
+    when(sqsClientMock.receiveMessage((ReceiveMessageRequest) anyObject())).thenReturn(createReceiveMessageResult(1),
+        new ReceiveMessageResult());
+
+    StandaloneConsumer consumer = startConsumer();
+    AmazonSQSConsumer sqsConsumer = (AmazonSQSConsumer) consumer.getConsumer();
+    waitForConsumer((MessageCounter) sqsConsumer.retrieveAdaptrisMessageListener(), 1, 10000);
+
+    verify(sqsClientMock, atLeast(1)).deleteMessage(any(DeleteMessageRequest.class));
+    LifecycleHelper.stopAndClose(consumer);
+  }
+
+  @Test
+  public void testSingleConsume_DeleteOnSuccess() throws Exception {
     // Return the ReceiveMessageResult with 1 message the first call, an empty result the second and all subsequent calls
     when(sqsClientMock.receiveMessage((ReceiveMessageRequest)anyObject())).thenReturn(
         createReceiveMessageResult(1),
         new ReceiveMessageResult());
 
-    startConsumer();
-    waitForConsumer(1, 10000);
+    MockMessageListener messageListener = new MockMessageListener(10);
+    AmazonSQSConsumer sqsConsumer = createConsumer(connectionMock);
+    sqsConsumer.setAlwaysDelete(Boolean.FALSE);
+    StandaloneConsumer consumer = new StandaloneConsumer(connectionMock, sqsConsumer);
+    consumer.registerAdaptrisMessageListener(messageListener);
+    LifecycleHelper.initAndStart(consumer);
+
+    waitForConsumer((MessageCounter) sqsConsumer.retrieveAdaptrisMessageListener(), 1, 10000);
     
     verify(sqsClientMock, atLeast(1)).deleteMessage(any(DeleteMessageRequest.class));
+    LifecycleHelper.stopAndClose(consumer);
   }
+
+  @Test
+  public void testSingleConsume_NoDeleteOnFailure() throws Exception {
+    // Return the ReceiveMessageResult with 1 message the first call, an empty result the second and all subsequent calls
+    when(sqsClientMock.receiveMessage((ReceiveMessageRequest) anyObject())).thenReturn(createReceiveMessageResult(1),
+        new ReceiveMessageResult());
+
+    NoCallbackListener messageListener = new NoCallbackListener();
+    AmazonSQSConsumer sqsConsumer = createConsumer(connectionMock);
+    sqsConsumer.setAlwaysDelete(Boolean.FALSE);
+    StandaloneConsumer consumer = new StandaloneConsumer(connectionMock, sqsConsumer);
+    consumer.registerAdaptrisMessageListener(messageListener);
+    LifecycleHelper.initAndStart(consumer);
+
+    waitForConsumer((MessageCounter) sqsConsumer.retrieveAdaptrisMessageListener(), 1, 10000);
+
+    verify(sqsClientMock, never()).deleteMessage(any(DeleteMessageRequest.class));
+    LifecycleHelper.stopAndClose(consumer);
+  }
+
   
   @Test
   public void testConsumeWithAmazonReceiveException() throws Exception {
-    // Return the ReceiveMessageResult with 1 message the first call, an empty result the second and all subsequent calls
     when(sqsClientMock.receiveMessage((ReceiveMessageRequest)anyObject())).thenThrow(new AmazonServiceException("expected"));
 
-    startConsumer();
-    waitForConsumer(0, 0);
+    StandaloneConsumer consumer = startConsumer();
+    AmazonSQSConsumer sqsConsumer = (AmazonSQSConsumer) consumer.getConsumer();
+    waitForConsumer((MessageCounter) sqsConsumer.retrieveAdaptrisMessageListener(), 0, 1100);
     verify(sqsClientMock, atLeast(0)).deleteMessage(any(DeleteMessageRequest.class));
+    LifecycleHelper.stopAndClose(consumer);
   }
   
   @Test
@@ -140,9 +179,11 @@ public class AwsConsumerTest extends ConsumerCase {
     
     doThrow(new AmazonServiceException("expected")).when(sqsClientMock).deleteMessage((DeleteMessageRequest)anyObject());
         
-    startConsumer();
-    waitForConsumer(1, 3000);
+    StandaloneConsumer consumer = startConsumer();
+    AmazonSQSConsumer sqsConsumer = (AmazonSQSConsumer) consumer.getConsumer();
+    waitForConsumer((MessageCounter) sqsConsumer.retrieveAdaptrisMessageListener(), 1, 3000);
     verify(sqsClientMock, atLeast(1)).deleteMessage(any(DeleteMessageRequest.class));
+    LifecycleHelper.stopAndClose(consumer);
   }
   
   @Test
@@ -156,39 +197,50 @@ public class AwsConsumerTest extends ConsumerCase {
         createReceiveMessageResult(1, attributes),
         new ReceiveMessageResult());
 
-    startConsumer();
+    MockMessageListener messageListener = new MockMessageListener(10);
+    AmazonSQSConsumer sqsConsumer = createConsumer(connectionMock);
     sqsConsumer.setPrefetchCount(1);
-    waitForConsumer(1, 10000);
+    StandaloneConsumer consumer = new StandaloneConsumer(connectionMock, sqsConsumer);
+    consumer.registerAdaptrisMessageListener(messageListener);
+    LifecycleHelper.initAndStart(consumer);
+
+    waitForConsumer((MessageCounter) sqsConsumer.retrieveAdaptrisMessageListener(), 1, 10000);
     
     verify(sqsClientMock, atLeast(1)).deleteMessage(any(DeleteMessageRequest.class));
-    assertEquals(1, messageListener.getMessages().size());
     assertEquals("myValue", messageListener.getMessages().get(0).getMetadataValue("myKey"));
     assertEquals("myValue2", messageListener.getMessages().get(0).getMetadataValue("myKey2"));
+    LifecycleHelper.stopAndClose(consumer);
   }
   
   @Test
-  public void testSingleConsumeWithSetReceieveAtts() throws Exception {
+  public void testSingleConsumeWithMessageAttributes() throws Exception {
     HashMap<String, String> attributes = new HashMap<>();
     attributes.put("myKey", "myValue");
     attributes.put("myKey2", "myValue2");
+    HashMap<String, String> msgAttributes = new HashMap<>();
+    msgAttributes.put("myMsgAttribute", "myMsgAttributeValue");
+    msgAttributes.put("myMsgAttribute2", "myMsgAttributeValue2");
+
     
     // Return the ReceiveMessageResult with 1 message the first call, an empty result the second and all subsequent calls
     when(sqsClientMock.receiveMessage((ReceiveMessageRequest)anyObject())).thenReturn(
-        createReceiveMessageResult(1, attributes),
+        createReceiveMessageResult(1, attributes, convertToMessageAttributes(msgAttributes)),
         new ReceiveMessageResult());
     
-    List<String> receiveAttributes = new ArrayList<>();
-    receiveAttributes.add("myReceiveKey");
-    receiveAttributes.add("myReceiveKey2");
-
-    startConsumer();
+    MockMessageListener messageListener = new MockMessageListener(10);
+    AmazonSQSConsumer sqsConsumer = createConsumer(connectionMock);
     sqsConsumer.setPrefetchCount(1);
-    waitForConsumer(1, 10000);
+    StandaloneConsumer consumer = new StandaloneConsumer(connectionMock, sqsConsumer);
+    consumer.registerAdaptrisMessageListener(messageListener);
+    LifecycleHelper.initAndStart(consumer);
+
+    waitForConsumer((MessageCounter) sqsConsumer.retrieveAdaptrisMessageListener(), 1, 10000);
     
-    verify(sqsClientMock, atLeast(1)).deleteMessage(any(DeleteMessageRequest.class));
     assertEquals(1, messageListener.getMessages().size());
     assertEquals("myValue", messageListener.getMessages().get(0).getMetadataValue("myKey"));
     assertEquals("myValue2", messageListener.getMessages().get(0).getMetadataValue("myKey2"));
+    assertEquals("myMsgAttributeValue", messageListener.getMessages().get(0).getMetadataValue("myMsgAttribute"));
+    assertEquals("myMsgAttributeValue2", messageListener.getMessages().get(0).getMetadataValue("myMsgAttribute2"));
   }
 
   @Test
@@ -198,11 +250,15 @@ public class AwsConsumerTest extends ConsumerCase {
     when(sqsClientMock.receiveMessage((ReceiveMessageRequest)anyObject())).thenReturn(
         receiveMessageResult, new ReceiveMessageResult());
 
-    startConsumer();
+    MockMessageListener messageListener = new MockMessageListener(10);
+    AmazonSQSConsumer sqsConsumer = createConsumer(connectionMock);
     sqsConsumer.setPrefetchCount(1);
-    waitForConsumer(1, 10000);
+    StandaloneConsumer consumer = new StandaloneConsumer(connectionMock, sqsConsumer);
+    consumer.registerAdaptrisMessageListener(messageListener);
+    LifecycleHelper.initAndStart(consumer);
 
-    verify(sqsClientMock, atLeast(1)).deleteMessage(any(DeleteMessageRequest.class));
+    waitForConsumer((MessageCounter) sqsConsumer.retrieveAdaptrisMessageListener(), 1, 10000);
+
     assertEquals(1, messageListener.getMessages().size());
     assertEquals(expected, messageListener.getMessages().get(0).getMetadataValue("SQSMessageID"));
   }
@@ -222,8 +278,9 @@ public class AwsConsumerTest extends ConsumerCase {
         createReceiveMessageResult(b5),
         new ReceiveMessageResult());
     
-    startConsumer();
-    waitForConsumer(numMsgs, 30000);
+    StandaloneConsumer consumer = startConsumer();
+    AmazonSQSConsumer sqsConsumer = (AmazonSQSConsumer) consumer.getConsumer();
+    waitForConsumer((MessageCounter) sqsConsumer.retrieveAdaptrisMessageListener(), numMsgs, 30000);
     Thread.sleep(500);
     
     verify(sqsClientMock, atLeast(numMsgs)).deleteMessage(any(DeleteMessageRequest.class));
@@ -234,7 +291,8 @@ public class AwsConsumerTest extends ConsumerCase {
     when(sqsClientMock.getQueueAttributes(any(GetQueueAttributesRequest.class))).thenReturn(
         new GetQueueAttributesResult().addAttributesEntry(QueueAttributeName.ApproximateNumberOfMessages.toString(), "10")
     );
-    startConsumer();
+    StandaloneConsumer consumer = startConsumer();
+    AmazonSQSConsumer sqsConsumer = (AmazonSQSConsumer) consumer.getConsumer();
     int messages = sqsConsumer.messagesRemaining();
 
     assertEquals(10, messages);
@@ -246,16 +304,12 @@ public class AwsConsumerTest extends ConsumerCase {
     when(sqsClientMock.getQueueAttributes(any(GetQueueAttributesRequest.class))).thenReturn(
         new GetQueueAttributesResult().addAttributesEntry(QueueAttributeName.ApproximateNumberOfMessages.toString(), "10")
     );
-    messageListener = new MockMessageListener(10);
+    MockMessageListener messageListener = new MockMessageListener(10);
 
-    sqsConsumer = new AmazonSQSConsumer();
-    sqsConsumer.registerConnection(connectionMock);
-    sqsConsumer.setDestination(new ConfiguredConsumeDestination("queue"));
-    sqsConsumer.setPoller(new QuartzCronPoller("*/1 * * * * ?"));
-    sqsConsumer.setReacquireLockBetweenMessages(true);
+    AmazonSQSConsumer sqsConsumer = createConsumer(connectionMock);
 
-    standaloneConsumer = new StandaloneConsumer(sqsConsumer);
-    standaloneConsumer.registerAdaptrisMessageListener(messageListener);
+    StandaloneConsumer consumer = new StandaloneConsumer(connectionMock, sqsConsumer);
+    consumer.registerAdaptrisMessageListener(messageListener);
     int messages = sqsConsumer.messagesRemaining();
 
     assertEquals(10, messages);
@@ -276,6 +330,30 @@ public class AwsConsumerTest extends ConsumerCase {
     
     return result;
   }
+
+  private ReceiveMessageResult createReceiveMessageResult(int numMsgs, Map<String, String> attributes,
+      Map<String, MessageAttributeValue> msgAttributes) {
+    // Create the messages to be received
+    GuidGenerator guidGenerator = new GuidGenerator();
+    List<Message> msgs = new ArrayList<Message>();
+    for (int i = 0; i < numMsgs; i++) {
+      msgs.add(new Message().withBody(payload).withAttributes(attributes)
+          .withMessageAttributes(msgAttributes)
+          .withMessageId(guidGenerator.getUUID()));
+    }
+    // Set up the connection mock to return a message list when called
+    ReceiveMessageResult result = new ReceiveMessageResult();
+    result.setMessages(msgs);
+    return result;
+  }
+
+  private Map<String, MessageAttributeValue> convertToMessageAttributes(Map<String,String> map) {
+    Map<String, MessageAttributeValue> result = new HashMap<>();
+    for (Entry<String, String> e : map.entrySet()) {
+      result.put(e.getKey(), new MessageAttributeValue().withDataType("String").withStringValue(e.getValue()));
+    }
+    return result;
+  }
   
   private ReceiveMessageResult createReceiveMessageResult(int numMsgs, Map<String, String> attributes) {
     // Create the messages to be received
@@ -292,49 +370,45 @@ public class AwsConsumerTest extends ConsumerCase {
     return result;
   }
 
-  private void waitForConsumer(final int numMsgs, final int maxWaitTime) throws Exception{
+  private void waitForConsumer(MessageCounter counter, final int numMsgs, final int maxWaitTime) throws Exception {
     final int waitInc = 100;
     int waitTime = 0;
     do {
       Thread.sleep(waitInc);
       waitTime += waitInc;
-    } while(messageListener.messageCount() < numMsgs && waitTime < maxWaitTime);
+    } while (counter.messageCount() < numMsgs && waitTime < maxWaitTime);
 
-    LifecycleHelper.stop(sqsConsumer);    
-    assertEquals(numMsgs, messageListener.messageCount());
+    assertEquals(numMsgs, counter.messageCount());
   }
-  
-  private void startConsumer() throws Exception {
-    messageListener = new MockMessageListener(10);
-    
-    sqsConsumer = new AmazonSQSConsumer();
-    sqsConsumer.registerConnection(connectionMock);
+
+  private static AmazonSQSConsumer createConsumer(AmazonSQSConnection conn) {
+    AmazonSQSConsumer sqsConsumer = new AmazonSQSConsumer();
     sqsConsumer.setDestination(new ConfiguredConsumeDestination("queue"));
     sqsConsumer.setPoller(new QuartzCronPoller("*/1 * * * * ?"));
     sqsConsumer.setReacquireLockBetweenMessages(true);
-    
-    standaloneConsumer = new StandaloneConsumer(sqsConsumer);
+    sqsConsumer.registerConnection(conn);
+    return sqsConsumer;
+  }
+
+  private StandaloneConsumer startConsumer() throws Exception {
+    MockMessageListener messageListener = new MockMessageListener(10);
+    AmazonSQSConsumer sqsConsumer = createConsumer(connectionMock);
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(connectionMock, sqsConsumer);
     standaloneConsumer.registerAdaptrisMessageListener(messageListener);
-    
-    LifecycleHelper.init(sqsConsumer);
-    LifecycleHelper.start(sqsConsumer);
+    LifecycleHelper.initAndStart(standaloneConsumer);
+    return standaloneConsumer;
   }
 
-  private void startConsumerWithAccountID() throws Exception {
-    messageListener = new MockMessageListener(10);
-
-    sqsConsumer = new AmazonSQSConsumer();
-    sqsConsumer.registerConnection(connectionMock);
-    sqsConsumer.setDestination(new ConfiguredConsumeDestination("queue"));
-    sqsConsumer.setPoller(new QuartzCronPoller("*/1 * * * * ?"));
-    sqsConsumer.setReacquireLockBetweenMessages(true);
+  private StandaloneConsumer startConsumerWithAccountID() throws Exception {
+    MockMessageListener messageListener = new MockMessageListener(10);
+    AmazonSQSConsumer sqsConsumer = createConsumer(connectionMock);
     sqsConsumer.setOwnerAwsAccountId("accountId");
 
-    standaloneConsumer = new StandaloneConsumer(sqsConsumer);
+    StandaloneConsumer standaloneConsumer = new StandaloneConsumer(connectionMock, sqsConsumer);
     standaloneConsumer.registerAdaptrisMessageListener(messageListener);
 
-    LifecycleHelper.init(sqsConsumer);
-    LifecycleHelper.start(sqsConsumer);
+    LifecycleHelper.initAndStart(standaloneConsumer);
+    return standaloneConsumer;
   }
   
   @Override
@@ -352,5 +426,18 @@ public class AwsConsumerTest extends ConsumerCase {
     sqsConsumer.setOwnerAwsAccountId("owner-account-id");
     StandaloneConsumer result = new StandaloneConsumer(conn, sqsConsumer);
     return result;
+  }
+
+  private class NoCallbackListener extends MockMessageListener {
+    public NoCallbackListener() {
+    }
+
+    // Fudge it so that we never trigger the callback, which "implies" an error
+    @Override
+    public void onAdaptrisMessage(AdaptrisMessage msg, Consumer<AdaptrisMessage> success) {
+      super.onAdaptrisMessage(msg, (m) -> {
+      });
+    }
+
   }
 }

--- a/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/AwsHelperTest.java
+++ b/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/AwsHelperTest.java
@@ -17,17 +17,42 @@
 package com.adaptris.aws.sqs;
 
 import static org.junit.Assert.assertEquals;
-
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.junit.Before;
 import org.junit.Test;
-
 import com.amazonaws.regions.Regions;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.model.GetQueueUrlRequest;
+import com.amazonaws.services.sqs.model.GetQueueUrlResult;
 
-public class AwsHelperTest {
+public class AwsHelperTest extends AwsHelper {
+  private static final String QUEUE_URL = "https://localhost/myqueueName";
+  private AmazonSQS sqsClientMock;
+  
+  @Before
+  public void setUp() throws Exception {
 
+    sqsClientMock = mock(AmazonSQS.class);
+    GetQueueUrlResult queueUrlResultMock = mock(GetQueueUrlResult.class);
+    when(queueUrlResultMock.getQueueUrl()).thenReturn(QUEUE_URL);
+    
+    when(sqsClientMock.getQueueUrl((GetQueueUrlRequest)anyObject())).thenReturn(queueUrlResultMock);
+  }
+  
   @Test
   public void testGetRegion() throws Exception {
-    assertEquals(Regions.EU_WEST_1.getName(), AwsHelper.formatRegion("eu-west-1"));
-    assertEquals(Regions.EU_WEST_1.getName(), AwsHelper.formatRegion("EU-WEST-1"));
-    assertEquals(Regions.EU_WEST_1.getName(), AwsHelper.formatRegion("amazon.eu-west-1"));
+    assertEquals(Regions.EU_WEST_1.getName(), formatRegion("eu-west-1"));
+    assertEquals(Regions.EU_WEST_1.getName(), formatRegion("EU-WEST-1"));
+    assertEquals(Regions.EU_WEST_1.getName(), formatRegion("amazon.eu-west-1"));
+    assertEquals("blah", formatRegion("blah"));
+  }
+  
+  @Test
+  public void testBuildQueueUrl() throws Exception {
+    assertEquals("https://localhost/anotherQueue", buildQueueUrl("https://localhost/anotherQueue", "", sqsClientMock));
+    assertEquals(QUEUE_URL, buildQueueUrl("myQueueName", "", sqsClientMock));
+    assertEquals(QUEUE_URL, buildQueueUrl("myQueueName", "ownerAccount", sqsClientMock));
   }
 }

--- a/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/LocalstackRoundtripTest.java
+++ b/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/LocalstackRoundtripTest.java
@@ -5,16 +5,14 @@ import static com.adaptris.aws.sqs.LocalstackHelper.areTestsEnabled;
 import static com.adaptris.aws.sqs.LocalstackHelper.getProperty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.BaseCase;
@@ -28,11 +26,7 @@ import com.adaptris.core.stubs.MockMessageListener;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.util.TimeInterval;
 import com.amazonaws.services.sqs.AmazonSQS;
-import com.amazonaws.services.sqs.model.GetQueueAttributesRequest;
-import com.amazonaws.services.sqs.model.GetQueueAttributesResult;
-import com.amazonaws.services.sqs.model.GetQueueUrlResult;
 import com.amazonaws.services.sqs.model.ListQueuesResult;
-import com.amazonaws.services.sqs.model.QueueAttributeName;
 
 // A new local stack instance; send some messages, and then receive then.
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -40,12 +34,12 @@ public class LocalstackRoundtripTest {
 
   private static final String MSG_CONTENTS = "hello world";
   private LocalstackHelper helper;
-  
+
   @Before
   public void setUp() throws Exception {
     helper = new LocalstackHelper();
   }
-  
+
   @After
   public void tearDown() throws Exception {
     helper.shutdown();
@@ -53,79 +47,63 @@ public class LocalstackRoundtripTest {
 
   @Test
   public void test_01_TestCreateQueue() throws Exception {
-    if (areTestsEnabled()) {
-      AmazonSQS sqs = helper.getSyncClient();
-      sqs.createQueue(getProperty(SQS_QUEUE));
-      ListQueuesResult result = sqs.listQueues();
-      System.err.println(result.getQueueUrls());
-    } else {
-      System.err.println("localstack disabled; not executing test_01_TestCreateQueue");
-    }
+    Assume.assumeTrue(areTestsEnabled());
+    AmazonSQS sqs = helper.getSyncClient();
+    sqs.createQueue(getProperty(SQS_QUEUE));
+    ListQueuesResult result = sqs.listQueues();
+    System.err.println(result.getQueueUrls());
   }
-  
+
   @Test
   public void test_02_TestPublish() throws Exception {
-    if (areTestsEnabled()) {
-      AmazonSQSProducer sqsProducer = new AmazonSQSProducer(new ConfiguredProduceDestination(getProperty(SQS_QUEUE)));
-      sqsProducer.withMessageAsyncCallback((e) -> {
-        try {
-          System.err.println(e.get().getMessageId());
-        }
-        catch (InterruptedException | ExecutionException e1) {
-        }
-      });
-      AmazonSQSConnection conn = helper.createConnection();
-      StandaloneProducer sp = new StandaloneProducer(conn, sqsProducer);
-      AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(MSG_CONTENTS);
+    Assume.assumeTrue(areTestsEnabled());
+    AmazonSQSProducer sqsProducer = new AmazonSQSProducer(new ConfiguredProduceDestination(getProperty(SQS_QUEUE)));
+    sqsProducer.withMessageAsyncCallback((e) -> {
+      try {
+        System.err.println(e.get().getMessageId());
+      } catch (InterruptedException | ExecutionException e1) {
+      }
+    });
+    AmazonSQSConnection conn = helper.createConnection();
+    StandaloneProducer sp = new StandaloneProducer(conn, sqsProducer);
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage(MSG_CONTENTS);
 
-      ServiceCase.execute(sp, msg);
-      
-      assertTrue(helper.messagesOnQueue(helper.toQueueURL(getProperty(SQS_QUEUE))) > 0);
-    }
-    else {
-      System.err.println("localstack disabled; not executing test_02_TestPublish");
-    }
+    ServiceCase.execute(sp, msg);
+
+    assertTrue(helper.messagesOnQueue(helper.toQueueURL(getProperty(SQS_QUEUE))) > 0);
   }
 
   @Test
   public void test_03_TestConsume() throws Exception {
     StandaloneConsumer standaloneConsumer = null;
     try {
-      if (areTestsEnabled()) {
-        AmazonSQSConsumer consumer = new AmazonSQSConsumer(new ConfiguredConsumeDestination(getProperty(SQS_QUEUE)));
-        AmazonSQSConnection conn = helper.createConnection();
-        FixedIntervalPoller poller = new FixedIntervalPoller(new TimeInterval(300L, TimeUnit.MILLISECONDS));
-        consumer.setPoller(poller);
-        consumer.setPrefetchCount(1);
+      Assume.assumeTrue(areTestsEnabled());
+      AmazonSQSConsumer consumer = new AmazonSQSConsumer(new ConfiguredConsumeDestination(getProperty(SQS_QUEUE)));
+      AmazonSQSConnection conn = helper.createConnection();
+      FixedIntervalPoller poller = new FixedIntervalPoller(new TimeInterval(300L, TimeUnit.MILLISECONDS));
+      consumer.setPoller(poller);
+      consumer.setPrefetchCount(1);
 
-        standaloneConsumer = new StandaloneConsumer(conn, consumer);
-        MockMessageListener listener = new MockMessageListener();
-        standaloneConsumer.registerAdaptrisMessageListener(listener);
-        // there is already a message from test_02
-        LifecycleHelper.initAndStart(standaloneConsumer);
-        
-        BaseCase.waitForMessages(listener,1, 5000);
-        assertEquals(1, listener.getMessages().size());
-        assertEquals(MSG_CONTENTS, listener.getMessages().get(0).getContent());
-      }
-      else {
-        System.err.println("localstack disabled; not executing test_02_TestPublish");
-      }
-    }
-    finally {
+      standaloneConsumer = new StandaloneConsumer(conn, consumer);
+      MockMessageListener listener = new MockMessageListener();
+      standaloneConsumer.registerAdaptrisMessageListener(listener);
+      // there is already a message from test_02
+      LifecycleHelper.initAndStart(standaloneConsumer);
+
+      BaseCase.waitForMessages(listener, 1, 5000);
+      assertEquals(1, listener.getMessages().size());
+      assertEquals(MSG_CONTENTS, listener.getMessages().get(0).getContent());
+    } finally {
       LifecycleHelper.stopAndClose(standaloneConsumer);
     }
   }
-  
-  
+
+
   @Test
   public void test_99_TestDeleteQueue() throws Exception {
-    if (areTestsEnabled()) {
-      AmazonSQS sqs = helper.getSyncClient();
-      sqs.deleteQueue(helper.toQueueURL(getProperty(SQS_QUEUE)));
-    } else {
-      System.err.println("localstack disabled; not executing test_99_TestDeleteQueue");
-    }
+    Assume.assumeTrue(areTestsEnabled());
+    AmazonSQS sqs = helper.getSyncClient();
+    sqs.deleteQueue(helper.toQueueURL(getProperty(SQS_QUEUE)));
   }
 
 }


### PR DESCRIPTION
- You can now configure a proper URL as your destination when consuming/producing; if it is so defined, then we don't need to invoke GetQueueUrlRequest which can have permissions associated with it.
- Add support in for messageListener callbacks, so if always-delete == false, then we issue a DeleteMessageRequest once the message is processed successfully, otherwise leaving it on the queue for DLQ / redelivery
- Updated the MessageAttributeValue test so that we actually set the message attributes
- Refactor the consumer test so that we have less assumptions about member variables.
