### PR TITLE
s3 ls: Add options to pageResults and set maxKeys

### DIFF
--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/ListOperation.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/ListOperation.java
@@ -97,7 +97,7 @@ public class ListOperation extends S3OperationImpl {
   /**
    * Specify max number of keys to be returned.
    */
-  @AdvancedConfig
+  @AdvancedConfig(rare=true)
   @Getter
   @Setter
   private Integer maxKeys;

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/ListOperation.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/ListOperation.java
@@ -18,12 +18,14 @@ package com.adaptris.aws.s3;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.Removal;
+import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.interlok.cloud.BlobListRenderer;
@@ -31,7 +33,8 @@ import com.adaptris.interlok.cloud.RemoteBlob;
 import com.adaptris.interlok.cloud.RemoteBlobFilter;
 import com.adaptris.interlok.config.DataInputParameter;
 import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
@@ -46,7 +49,7 @@ import lombok.Setter;
 @ComponentProfile(summary = "List of files based on S3 key",
     since = "3.9.1")
 @XStreamAlias("amazon-s3-list")
-@DisplayOrder(order = {"bucketName", "key", "filter", "filterSuffix"})
+@DisplayOrder(order = {"bucketName", "key", "pageResults", "maxKeys", "filter", "filterSuffix"})
 public class ListOperation extends S3OperationImpl {
   private transient boolean warningLogged;
 
@@ -77,6 +80,28 @@ public class ListOperation extends S3OperationImpl {
   @Setter
   private BlobListRenderer outputStyle;
 
+  /**
+   * Specify whether to page over results.
+   *
+   * <p>
+   *   If set to true will return all results, as oppose to the first n, where n is max-keys (AWS default: 1000).
+   *   Default is false for backwards compatibility reasons.
+   * </p>
+   */
+  @AdvancedConfig
+  @Getter
+  @Setter
+  @InputFieldDefault(value = "false")
+  private Boolean pageResults;
+
+  /**
+   * Specify max number of keys to be returned.
+   */
+  @AdvancedConfig
+  @Getter
+  @Setter
+  private Integer maxKeys;
+
   public ListOperation() {
   }
 
@@ -85,21 +110,31 @@ public class ListOperation extends S3OperationImpl {
     AmazonS3Client s3 = wrapper.amazonClient();
     String bucket = getBucketName().extract(msg);
     String key = getKey().extract(msg);
-    ObjectListing listing =  s3.listObjects(bucket, key);
-    filter(listing, msg);
-    outputStyle().render(filter(listing, msg), msg);
+    ListObjectsV2Request request = new ListObjectsV2Request()
+            .withBucketName(bucket)
+            .withPrefix(key);
+    if(getMaxKeys() != null){
+      request.setMaxKeys(getMaxKeys());
+    }
+    outputStyle().render(filter(s3, request, msg), msg);
   }
 
-  private Collection<RemoteBlob> filter(ObjectListing listing, AdaptrisMessage msg) throws Exception {
+  private Collection<RemoteBlob> filter(AmazonS3Client s3, ListObjectsV2Request request, AdaptrisMessage msg) throws Exception {
     Collection<RemoteBlob> list = new ArrayList<>();
     RemoteBlobFilter filterToUse = blobFilter(msg);
-    for (S3ObjectSummary summary : listing.getObjectSummaries()) {
-      RemoteBlob blob = new RemoteBlob.Builder().setBucket(summary.getBucketName()).setLastModified(summary.getLastModified().getTime())
-          .setName(summary.getKey()).setSize(summary.getSize()).build();
-      if (filterToUse.accept(blob)) {
-        list.add(blob);
+    ListObjectsV2Result listing;
+    do {
+      listing = s3.listObjectsV2(request);
+      for (S3ObjectSummary summary : listing.getObjectSummaries()) {
+        RemoteBlob blob = new RemoteBlob.Builder().setBucket(summary.getBucketName()).setLastModified(summary.getLastModified().getTime())
+                .setName(summary.getKey()).setSize(summary.getSize()).build();
+        if (filterToUse.accept(blob)) {
+          list.add(blob);
+        }
       }
-    }
+      String token = listing.getNextContinuationToken();
+      request.setContinuationToken(token);
+    } while (pageResults() && listing.isTruncated());
     return list;
   }
 
@@ -123,6 +158,20 @@ public class ListOperation extends S3OperationImpl {
 
   public ListOperation withFilter(RemoteBlobFilter filter) {
     setFilter(filter);
+    return this;
+  }
+
+  private boolean pageResults(){
+    return BooleanUtils.toBooleanDefaultIfNull(getPageResults(),false);
+  }
+
+  public ListOperation withPageResults(Boolean paging){
+    setPageResults(paging);
+    return this;
+  }
+
+  public ListOperation withMaxKeys(Integer maxKeys){
+    setMaxKeys(maxKeys);
     return this;
   }
 

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3BucketList.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3BucketList.java
@@ -93,7 +93,7 @@ public class S3BucketList extends ServiceImp implements DynamicPollingTemplate.T
   /**
    * Specify max number of keys to be returned.
    */
-  @AdvancedConfig
+  @AdvancedConfig(rare=true)
   @Getter
   @Setter
   private Integer maxKeys;

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3BucketList.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3BucketList.java
@@ -4,6 +4,7 @@ import javax.validation.constraints.NotBlank;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisConnection;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ConnectedService;
@@ -75,6 +76,28 @@ public class S3BucketList extends ServiceImp implements DynamicPollingTemplate.T
   @AdvancedConfig
   private RemoteBlobFilter filter;
 
+  /**
+   * Specify whether to page over results.
+   *
+   * <p>
+   *   If set to true will return all results, as oppose to the first n, where n is max-keys (AWS default: 1000).
+   *   Default is false for backwards compatibility reasons.
+   * </p>
+   */
+  @AdvancedConfig
+  @Getter
+  @Setter
+  @InputFieldDefault(value = "false")
+  private Boolean pageResults;
+
+  /**
+   * Specify max number of keys to be returned.
+   */
+  @AdvancedConfig
+  @Getter
+  @Setter
+  private Integer maxKeys;
+
   @Override
   public void prepare() throws CoreException {}
 
@@ -117,6 +140,15 @@ public class S3BucketList extends ServiceImp implements DynamicPollingTemplate.T
     return this;
   }
 
+  public S3BucketList withPageResults(Boolean pageResults){
+    setPageResults(pageResults);
+    return this;
+  }
+
+  public S3BucketList withMaxKeys(Integer maxKeys){
+    setMaxKeys(maxKeys);
+    return this;
+  }
 
   public S3BucketList withOutputStyle(BlobListRenderer outputStyle) {
     setOutputStyle(outputStyle);
@@ -125,6 +157,8 @@ public class S3BucketList extends ServiceImp implements DynamicPollingTemplate.T
 
   private S3Service buildService() {
     ListOperation op = new ListOperation().withFilter(getFilter()).withOutputStyle(getOutputStyle())
+        .withMaxKeys(getMaxKeys())
+        .withPageResults(getPageResults())
         .withBucketName(new ConstantDataInputParameter(getBucket()))
         .withKey(new ConstantDataInputParameter(getKey()));
     return new S3Service(getConnection(), op);

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/BucketListTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/BucketListTest.java
@@ -2,15 +2,19 @@ package com.adaptris.aws.s3;
 
 import static com.adaptris.aws.s3.MockedOperationTest.createSummary;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -19,7 +23,8 @@ import com.adaptris.core.ServiceException;
 import com.adaptris.interlok.cloud.BlobListRenderer;
 import com.adaptris.interlok.cloud.RemoteBlobFilterWrapper;
 import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 
 public class BucketListTest {
@@ -31,16 +36,23 @@ public class BucketListTest {
     ClientWrapper wrapper = new ClientWrapperImpl(client);
     Mockito.when(mockConnection.retrieveConnection(any())).thenReturn(wrapper);
 
-    ObjectListing listing = Mockito.mock(ObjectListing.class);
+    ListObjectsV2Result listing = Mockito.mock(ListObjectsV2Result.class);
     List<S3ObjectSummary> summaries = new ArrayList<>(Arrays.asList(createSummary("srcBucket", "srcKeyPrefix/"),
         createSummary("srcBucket", "srcKeyPrefix/file.json"), createSummary("srcBucket", "srcKeyPrefix/file2.csv")));
     Mockito.when(listing.getObjectSummaries()).thenReturn(summaries);
-    Mockito.when(client.listObjects(anyString(), anyString())).thenReturn(listing);
+    ArgumentCaptor<ListObjectsV2Request> argument = ArgumentCaptor.forClass(ListObjectsV2Request.class);
+    Mockito.when(client.listObjectsV2(argument.capture())).thenReturn(listing);
 
     S3BucketList bucket =
         new S3BucketList().withConnection(mockConnection).withBucket("srcBucket").withKey("srcKeyPrefix").withOutputStyle(null);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     ServiceCase.execute(bucket, msg);
+
+    Mockito.verify(client, Mockito.times(1)).listObjectsV2(any(ListObjectsV2Request.class));
+    assertEquals("srcBucket", argument.getValue().getBucketName());
+    assertEquals("srcKeyPrefix", argument.getValue().getPrefix());
+    assertNull(argument.getValue().getMaxKeys());
+
     List<String> lines = IOUtils.readLines(new StringReader(msg.getContent()));
     assertEquals(3, lines.size());
   }
@@ -52,11 +64,12 @@ public class BucketListTest {
     ClientWrapper wrapper = new ClientWrapperImpl(client);
     Mockito.when(mockConnection.retrieveConnection(any())).thenReturn(wrapper);
 
-    ObjectListing listing = Mockito.mock(ObjectListing.class);
+    ListObjectsV2Result listing = Mockito.mock(ListObjectsV2Result.class);
     List<S3ObjectSummary> summaries = new ArrayList<>(Arrays.asList(createSummary("srcBucket", "srcKeyPrefix/"),
         createSummary("srcBucket", "srcKeyPrefix/file.json"), createSummary("srcBucket", "srcKeyPrefix/file2.csv")));
     Mockito.when(listing.getObjectSummaries()).thenReturn(summaries);
-    Mockito.when(client.listObjects(anyString(), anyString())).thenReturn(listing);
+    ArgumentCaptor<ListObjectsV2Request> argument = ArgumentCaptor.forClass(ListObjectsV2Request.class);
+    Mockito.when(client.listObjectsV2(argument.capture())).thenReturn(listing);
     RemoteBlobFilterWrapper filter =
         new RemoteBlobFilterWrapper().withFilterExpression(".*\\.json").withFilterImp(RegexFileFilter.class.getCanonicalName());
 
@@ -64,6 +77,12 @@ public class BucketListTest {
         new S3BucketList().withConnection(mockConnection).withBucket("srcBucket").withKey("srcKeyPrefix").withFilter(filter);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     ServiceCase.execute(bucket, msg);
+
+    Mockito.verify(client, Mockito.times(1)).listObjectsV2(any(ListObjectsV2Request.class));
+    assertEquals("srcBucket", argument.getValue().getBucketName());
+    assertEquals("srcKeyPrefix", argument.getValue().getPrefix());
+    assertNull(argument.getValue().getMaxKeys());
+
     List<String> lines = IOUtils.readLines(new StringReader(msg.getContent()));
     assertEquals(1, lines.size());
   }
@@ -80,14 +99,96 @@ public class BucketListTest {
         new S3BucketList().withConnection(mockConnection).withBucket("srcBucket").withKey("srcKeyPrefix")
             .withOutputStyle(brokenRender);
 
-    ObjectListing listing = Mockito.mock(ObjectListing.class);
+    ListObjectsV2Result listing = Mockito.mock(ListObjectsV2Result.class);
     List<S3ObjectSummary> summaries = new ArrayList<>(Arrays.asList(createSummary("srcBucket", "srcKeyPrefix/"),
         createSummary("srcBucket", "srcKeyPrefix/file.json"), createSummary("srcBucket", "srcKeyPrefix/file2.csv")));
     Mockito.when(listing.getObjectSummaries()).thenReturn(summaries);
-    Mockito.when(client.listObjects(anyString(), anyString())).thenReturn(listing);
+    Mockito.when(client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(listing);
 
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     ServiceCase.execute(bucket, msg);
+  }
+
+  @Test
+  public void testService_MaxKeys() throws Exception {
+    AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
+    AmazonS3Connection mockConnection = Mockito.mock(AmazonS3Connection.class);
+    ClientWrapper wrapper = new ClientWrapperImpl(client);
+    Mockito.when(mockConnection.retrieveConnection(any())).thenReturn(wrapper);
+
+    ListObjectsV2Result listing = Mockito.mock(ListObjectsV2Result.class);
+    List<S3ObjectSummary> summaries = new ArrayList<>(Arrays.asList(createSummary("srcBucket", "srcKeyPrefix/"),
+        createSummary("srcBucket", "srcKeyPrefix/file.json")));
+    Mockito.when(listing.getObjectSummaries()).thenReturn(summaries);
+    ArgumentCaptor<ListObjectsV2Request> argument = ArgumentCaptor.forClass(ListObjectsV2Request.class);
+    Mockito.when(client.listObjectsV2(argument.capture())).thenReturn(listing);
+
+    S3BucketList bucket =
+        new S3BucketList().withConnection(mockConnection).withBucket("srcBucket").withKey("srcKeyPrefix").withMaxKeys(2).withOutputStyle(null);
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    ServiceCase.execute(bucket, msg);
+
+    Mockito.verify(client, Mockito.times(1)).listObjectsV2(any(ListObjectsV2Request.class));
+    assertEquals("srcBucket", argument.getValue().getBucketName());
+    assertEquals("srcKeyPrefix", argument.getValue().getPrefix());
+    assertNotNull(argument.getValue().getMaxKeys());
+    assertEquals(Optional.of(2), Optional.ofNullable(argument.getValue().getMaxKeys()));
+
+    List<String> lines = IOUtils.readLines(new StringReader(msg.getContent()));
+    assertEquals(2, lines.size());
+  }
+
+  @Test
+  public void testService_Paging() throws Exception {
+    AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
+    AmazonS3Connection mockConnection = Mockito.mock(AmazonS3Connection.class);
+    ClientWrapper wrapper = new ClientWrapperImpl(client);
+    Mockito.when(mockConnection.retrieveConnection(any())).thenReturn(wrapper);
+
+    ListObjectsV2Result listing = Mockito.mock(ListObjectsV2Result.class);
+    List<S3ObjectSummary> summaries = new ArrayList<>(Arrays.asList(
+        createSummary("srcBucket", "srcKeyPrefix/"),
+        createSummary("srcBucket", "srcKeyPrefix/file.json")));
+    Mockito.when(listing.getObjectSummaries()).thenReturn(summaries);
+    Mockito.when(listing.getNextContinuationToken()).thenReturn("abc123");
+    Mockito.when(listing.isTruncated()).thenReturn(true);
+
+    ListObjectsV2Result listing2 = Mockito.mock(ListObjectsV2Result.class);
+    List<S3ObjectSummary> summaries2 = new ArrayList<>(Collections.singletonList(
+        createSummary("srcBucket", "srcKeyPrefix/file2.csv")));
+    Mockito.when(listing2.getObjectSummaries()).thenReturn(summaries2);
+
+    ArgumentCaptor<ListObjectsV2Request> argument = ArgumentCaptor.forClass(ListObjectsV2Request.class);
+
+    Mockito.when(client.listObjectsV2(argument.capture())).thenReturn(listing, listing2);
+
+    S3BucketList bucket =
+        new S3BucketList().withConnection(mockConnection).withBucket("srcBucket").withKey("srcKeyPrefix").withMaxKeys(2)
+            .withPageResults(true).withOutputStyle(null);
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    ServiceCase.execute(bucket, msg);
+
+    Mockito.verify(client, Mockito.times(2)).listObjectsV2(any(ListObjectsV2Request.class));
+
+    List<ListObjectsV2Request> capturedRequests = argument.getAllValues();
+
+    assertEquals("srcBucket", capturedRequests.get(0).getBucketName());
+    assertEquals("srcKeyPrefix", capturedRequests.get(0).getPrefix());
+    assertNull(capturedRequests.get(0).getContinuationToken());
+    assertNotNull(capturedRequests.get(0).getMaxKeys());
+    assertEquals(Optional.of(2), Optional.ofNullable(capturedRequests.get(0).getMaxKeys()));
+
+
+    assertEquals("srcBucket", capturedRequests.get(1).getBucketName());
+    assertEquals("srcKeyPrefix", capturedRequests.get(1).getPrefix());
+    // getContinuationToken not captured in argument capture possibly due to reuse of object in loop
+    // assertEquals("abc123", capturedRequests.get(1).getContinuationToken());
+    assertNotNull(capturedRequests.get(1).getMaxKeys());
+    assertEquals(Optional.of(2), Optional.ofNullable(capturedRequests.get(1).getMaxKeys()));
+
+
+    List<String> lines = IOUtils.readLines(new StringReader(msg.getContent()));
+    assertEquals(3, lines.size());
   }
 
 }

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/MockedOperationTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/MockedOperationTest.java
@@ -3,6 +3,7 @@ package com.adaptris.aws.s3;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import java.io.ByteArrayInputStream;
@@ -28,7 +29,8 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CopyObjectResult;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.GetObjectTaggingResult;
-import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
@@ -281,13 +283,13 @@ public class MockedOperationTest {
   public void testListOperationNoFilter() throws Exception {
     AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
     TransferManager transferManager = Mockito.mock(TransferManager.class);
-    ObjectListing result = Mockito.mock(ObjectListing.class);
+    ListObjectsV2Result result = Mockito.mock(ListObjectsV2Result.class);
     S3ObjectSummary sbase = createSummary("srcBucket", "srcKeyPrefix/");
     S3ObjectSummary s1 = createSummary("srcBucket", "srcKeyPrefix/file.json");
     S3ObjectSummary s2 = createSummary("srcBucket", "srcKeyPrefix/file2.csv");
     List<S3ObjectSummary> list = new ArrayList<>(Arrays.asList(sbase, s1, s2));
     Mockito.when(result.getObjectSummaries()).thenReturn(list);
-    Mockito.when(client.listObjects(anyString(), anyString())).thenReturn(result);
+    Mockito.when(client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(result);
     ListOperation ls = new ListOperation()
         .withBucketName(new ConstantDataInputParameter("srcBucket")).withKey(new ConstantDataInputParameter("srcKeyPrefix/"));
 
@@ -305,14 +307,14 @@ public class MockedOperationTest {
   public void testListOperation_LegacyFilter() throws Exception {
     AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
     TransferManager transferManager = Mockito.mock(TransferManager.class);
-    ObjectListing result = Mockito.mock(ObjectListing.class);
+    ListObjectsV2Result result = Mockito.mock(ListObjectsV2Result.class);
     S3ObjectSummary sbase = createSummary("srcBucket", "srcKeyPrefix/");
     S3ObjectSummary s1 = createSummary("srcBucket", "srcKeyPrefix/file.json");
     S3ObjectSummary s2 = createSummary("srcBucket", "srcKeyPrefix/file2.csv");
 
     List<S3ObjectSummary> list = new ArrayList<>(Arrays.asList(sbase, s1, s2));
     Mockito.when(result.getObjectSummaries()).thenReturn(list);
-    Mockito.when(client.listObjects(anyString(), anyString())).thenReturn(result);
+    Mockito.when(client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(result);
     ListOperation ls = new ListOperation()
         .withFilterSuffix(new ConstantDataInputParameter(".json"))
         .withBucketName(new ConstantDataInputParameter("srcBucket")).withKey(new ConstantDataInputParameter("srcKeyPrefix/"));
@@ -327,14 +329,14 @@ public class MockedOperationTest {
   public void testListOperation_RemoteBlobFilter() throws Exception {
     AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
     TransferManager transferManager = Mockito.mock(TransferManager.class);
-    ObjectListing result = Mockito.mock(ObjectListing.class);
+    ListObjectsV2Result result = Mockito.mock(ListObjectsV2Result.class);
     S3ObjectSummary sbase = createSummary("srcBucket", "srcKeyPrefix/");
     S3ObjectSummary s1 = createSummary("srcBucket", "srcKeyPrefix/file.json");
     S3ObjectSummary s2 = createSummary("srcBucket", "srcKeyPrefix/file2.csv");
 
     List<S3ObjectSummary> list = new ArrayList<>(Arrays.asList(sbase, s1, s2));
     Mockito.when(result.getObjectSummaries()).thenReturn(list);
-    Mockito.when(client.listObjects(anyString(), anyString())).thenReturn(result);
+    Mockito.when(client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(result);
     RemoteBlobFilterWrapper filter =
         new RemoteBlobFilterWrapper().withFilterExpression(".*\\.json").withFilterImp(RegexFileFilter.class.getCanonicalName());
     ListOperation ls = new ListOperation().withFilter(filter)


### PR DESCRIPTION
## Motivation

List-Operations only returned the first 1000 results

## Modification

The following changes where made:

- Switch to using list-operation-v2
- Set max keys when provided
- Page over results based on page-results

## Result

User can now control where they would like all the results, backwards compatibility is also preserved

## Testing

Using localstack:

```bash
echo "hello" > file.txt
awslocal mb s3://test-bucket
awslocal s3 copy ./file.txt s3://test-bucket/file1.txt
awslocal s3 copy ./file.txt s3://test-bucket/file2.txt
awslocal s3 copy ./file.txt s3://test-bucket/file3.txt
```

```xml
<amazon-s3-service>
  <unique-id>sick-khorana</unique-id>
  <connection class="amazon-s3-connection">
    <unique-id>eager-lovelace</unique-id>
    <region>eu-west-1</region>
    <custom-endpoint>
      <service-endpoint>localhost:4572</service-endpoint>
      <signing-region>eu-west-1</signing-region>
    </custom-endpoint>
    <force-path-style-access>true</force-path-style-access>
  </connection>
  <operation class="amazon-s3-list">
    <bucket-name class="constant-data-input-parameter">
      <value>test-bucket</value>
    </bucket-name>
    <key class="constant-data-input-parameter">
      <value>/</value>
    </key>
    <page-results>true</page-results>
    <max-keys>1</max-keys>
  </operation>
</amazon-s3-service>
```
**Output**
```
file1.txt
file2.txt
file3.txt
```

