### PR TITLE
Interlok 3295 aws apache http signer

### DIFF
--- a/interlok-aws-common/build.gradle
+++ b/interlok-aws-common/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
   }
   compile ("com.fasterxml.jackson.core:jackson-databind:2.11.0")
+  compile ("com.adaptris:interlok-apache-http:$interlokCoreVersion")
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {

--- a/interlok-aws-common/src/main/java/com/adaptris/aws/apache/interceptor/ApacheSigningInterceptor.java
+++ b/interlok-aws-common/src/main/java/com/adaptris/aws/apache/interceptor/ApacheSigningInterceptor.java
@@ -25,7 +25,7 @@ import lombok.SneakyThrows;
 
 /**
  * {@code RequestInterceptorBuilder} implementation that creates an interceptor to sign requests
- * sent to AWS Elasticsearch Service
+ * made to AWS using AWS4Signer
  * 
  * <p>
  * Note that this uses the interceptor from
@@ -39,7 +39,7 @@ import lombok.SneakyThrows;
 @XStreamAlias("aws-apache-signing-interceptor")
 @AdapterComponent
 @ComponentProfile(
-    summary = "Supplies an Apache HTTP Request Interceptor used to sign requests made an AWS managed Elasticsearch instance",
+    summary = "Supplies an Apache HTTP Request Interceptor used to sign requests made to AWS using AWS4Signer",
     tag = "amazon,aws,elastic,elasticsearch", since = "3.10.2")
 @DisplayOrder(order = {"serviceName", "region", "credentials"})
 @NoArgsConstructor

--- a/interlok-aws-common/src/main/java/com/adaptris/aws/apache/interceptor/ApacheSigningInterceptor.java
+++ b/interlok-aws-common/src/main/java/com/adaptris/aws/apache/interceptor/ApacheSigningInterceptor.java
@@ -1,0 +1,117 @@
+package com.adaptris.aws.apache.interceptor;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.http.HttpRequestInterceptor;
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.aws.AWSCredentialsProviderBuilder;
+import com.adaptris.aws.DefaultAWSAuthentication;
+import com.adaptris.aws.StaticCredentialsBuilder;
+import com.adaptris.core.http.apache.request.RequestInterceptorBuilder;
+import com.adaptris.interlok.util.Args;
+import com.amazonaws.auth.AWS4Signer;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.http.AWSRequestSigningApacheInterceptor;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+import lombok.SneakyThrows;
+
+/**
+ * {@code RequestInterceptorBuilder} implementation that creates an interceptor to sign requests
+ * sent to AWS Elasticsearch Service
+ * 
+ * <p>
+ * Note that this uses the interceptor from
+ * <a href="https://github.com/awslabs/aws-request-signing-apache-interceptor/">this github
+ * project</a> verbatim. It is in fact copied locally into a {@code com.amazonaws.http} package
+ * since it is not officially published in any publicly available artifact.
+ * </p>
+ * 
+ * @config aws-apache-signing-interceptor
+ */
+@XStreamAlias("aws-apache-signing-interceptor")
+@AdapterComponent
+@ComponentProfile(
+    summary = "Supplies an Apache HTTP Request Interceptor used to sign requests made an AWS managed Elasticsearch instance",
+    tag = "amazon,aws,elastic,elasticsearch", since = "3.10.2")
+@DisplayOrder(order = {"serviceName", "region", "credentials"})
+@NoArgsConstructor
+public class ApacheSigningInterceptor implements RequestInterceptorBuilder {
+
+  /**
+   * The serviceName to use with {@code AWS4Signer}.
+   * <p>
+   * From the {@code AWS4Signer} javadocs; this is the service name that is used when calculating
+   * the signature.
+   * </p>
+   */
+  @Getter
+  @Setter
+  @NotBlank
+  @NonNull
+  private String serviceName;
+  /**
+   * The region to use with {@code AWS4Signer}.
+   * <p>
+   * From the {@code AWS4Signer} javadocs; this is the region name that is used when calculating the
+   * signature.
+   * </p>
+   */
+  @Getter
+  @Setter
+  @NotBlank
+  @NonNull
+  private String regionName;
+
+  /**
+   * How to provide Credentials for AWS.
+   * <p>
+   * If not specified, then a static credentials provider with a default provider chain will be
+   * used.
+   * </p>
+   */
+  @Getter
+  @Setter
+  @Valid
+  @InputFieldDefault(value = "aws-static-credentials-builder with default credentials")
+  private AWSCredentialsProviderBuilder credentials;
+
+
+  @Override
+  @SneakyThrows(Exception.class)
+  public HttpRequestInterceptor build() {
+    String service = Args.notBlank(getServiceName(), "service-name");
+    String region = Args.notBlank(getRegionName(), "region-name");
+    AWS4Signer signer = new AWS4Signer();
+    signer.setServiceName(service);
+    signer.setRegionName(region);
+    return new AWSRequestSigningApacheInterceptor(service, signer, credentialsProvider().build());
+  }
+
+  private AWSCredentialsProviderBuilder credentialsProvider() {
+    return ObjectUtils.defaultIfNull(getCredentials(),
+        new StaticCredentialsBuilder().withAuthentication(new DefaultAWSAuthentication()));
+  }
+
+  public ApacheSigningInterceptor withRegion(String region) {
+    setRegionName(region);
+    return this;
+  }
+
+  public ApacheSigningInterceptor withService(String service) {
+    setServiceName(service);
+    return this;
+  }
+
+  public ApacheSigningInterceptor withCredentials(AWSCredentialsProviderBuilder creds) {
+    setCredentials(creds);
+    return this;
+  }
+}

--- a/interlok-aws-common/src/main/java/com/amazonaws/http/AWSRequestSigningApacheInterceptor.java
+++ b/interlok-aws-common/src/main/java/com/amazonaws/http/AWSRequestSigningApacheInterceptor.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2012-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+package com.amazonaws.http;
+
+import com.amazonaws.DefaultRequest;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.Signer;
+import org.apache.http.Header;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.HttpException;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.BasicHttpEntity;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.protocol.HttpContext;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.apache.http.protocol.HttpCoreContext.HTTP_TARGET_HOST;
+
+/**
+ * An {@link HttpRequestInterceptor} that signs requests using any AWS {@link Signer}
+ * and {@link AWSCredentialsProvider}.
+ */
+// Since we use lombok, we abuse the Generated annotation to exclude this from jacoco (!)
+@lombok.Generated
+public class AWSRequestSigningApacheInterceptor implements HttpRequestInterceptor {
+    /**
+     * The service that we're connecting to. Technically not necessary.
+     * Could be used by a future Signer, though.
+     */
+    private final String service;
+
+    /**
+     * The particular signer implementation.
+     */
+    private final Signer signer;
+
+    /**
+     * The source of AWS credentials for signing.
+     */
+    private final AWSCredentialsProvider awsCredentialsProvider;
+
+    /**
+     *
+     * @param service service that we're connecting to
+     * @param signer particular signer implementation
+     * @param awsCredentialsProvider source of AWS credentials for signing
+     */
+    public AWSRequestSigningApacheInterceptor(final String service,
+                                final Signer signer,
+                                final AWSCredentialsProvider awsCredentialsProvider) {
+        this.service = service;
+        this.signer = signer;
+        this.awsCredentialsProvider = awsCredentialsProvider;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void process(final HttpRequest request, final HttpContext context)
+            throws HttpException, IOException {
+        URIBuilder uriBuilder;
+        try {
+            uriBuilder = new URIBuilder(request.getRequestLine().getUri());
+        } catch (URISyntaxException e) {
+            throw new IOException("Invalid URI" , e);
+        }
+
+        // Copy Apache HttpRequest to AWS DefaultRequest
+        DefaultRequest<?> signableRequest = new DefaultRequest<>(service);
+
+        HttpHost host = (HttpHost) context.getAttribute(HTTP_TARGET_HOST);
+        if (host != null) {
+            signableRequest.setEndpoint(URI.create(host.toURI()));
+        }
+        final HttpMethodName httpMethod =
+                HttpMethodName.fromValue(request.getRequestLine().getMethod());
+        signableRequest.setHttpMethod(httpMethod);
+        try {
+            signableRequest.setResourcePath(uriBuilder.build().getRawPath());
+        } catch (URISyntaxException e) {
+            throw new IOException("Invalid URI" , e);
+        }
+
+        if (request instanceof HttpEntityEnclosingRequest) {
+            HttpEntityEnclosingRequest httpEntityEnclosingRequest =
+                    (HttpEntityEnclosingRequest) request;
+            if (httpEntityEnclosingRequest.getEntity() != null) {
+                signableRequest.setContent(httpEntityEnclosingRequest.getEntity().getContent());
+            }
+        }
+        signableRequest.setParameters(nvpToMapParams(uriBuilder.getQueryParams()));
+        signableRequest.setHeaders(headerArrayToMap(request.getAllHeaders()));
+
+        // Sign it
+        signer.sign(signableRequest, awsCredentialsProvider.getCredentials());
+
+        // Now copy everything back
+        request.setHeaders(mapToHeaderArray(signableRequest.getHeaders()));
+        if (request instanceof HttpEntityEnclosingRequest) {
+            HttpEntityEnclosingRequest httpEntityEnclosingRequest =
+                    (HttpEntityEnclosingRequest) request;
+            if (httpEntityEnclosingRequest.getEntity() != null) {
+                BasicHttpEntity basicHttpEntity = new BasicHttpEntity();
+                basicHttpEntity.setContent(signableRequest.getContent());
+                httpEntityEnclosingRequest.setEntity(basicHttpEntity);
+            }
+        }
+    }
+
+    /**
+     *
+     * @param params list of HTTP query params as NameValuePairs
+     * @return a multimap of HTTP query params
+     */
+    private static Map<String, List<String>> nvpToMapParams(final List<NameValuePair> params) {
+        Map<String, List<String>> parameterMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        for (NameValuePair nvp : params) {
+            List<String> argsList =
+                    parameterMap.computeIfAbsent(nvp.getName(), k -> new ArrayList<>());
+            argsList.add(nvp.getValue());
+        }
+        return parameterMap;
+    }
+
+    /**
+     * @param headers modeled Header objects
+     * @return a Map of header entries
+     */
+    private static Map<String, String> headerArrayToMap(final Header[] headers) {
+        Map<String, String> headersMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        for (Header header : headers) {
+            if (!skipHeader(header)) {
+                headersMap.put(header.getName(), header.getValue());
+            }
+        }
+        return headersMap;
+    }
+
+    /**
+     * @param header header line to check
+     * @return true if the given header should be excluded when signing
+     */
+    private static boolean skipHeader(final Header header) {
+        return ("content-length".equalsIgnoreCase(header.getName())
+                && "0".equals(header.getValue())) // Strip Content-Length: 0
+                || "host".equalsIgnoreCase(header.getName()); // Host comes from endpoint
+    }
+
+    /**
+     * @param mapHeaders Map of header entries
+     * @return modeled Header objects
+     */
+    private static Header[] mapToHeaderArray(final Map<String, String> mapHeaders) {
+        Header[] headers = new Header[mapHeaders.size()];
+        int i = 0;
+        for (Map.Entry<String, String> headerEntry : mapHeaders.entrySet()) {
+            headers[i++] = new BasicHeader(headerEntry.getKey(), headerEntry.getValue());
+        }
+        return headers;
+    }
+}

--- a/interlok-aws-common/src/main/java/com/amazonaws/http/package-info.java
+++ b/interlok-aws-common/src/main/java/com/amazonaws/http/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * <p>
+ * Taken directly from <a href="https://github.com/awslabs/aws-request-signing-apache-interceptor/">github</a> which
+ * does not appear to be published as an artifact anywhere.
+ * </p>
+ */
+package com.amazonaws.http;

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/apache/interceptor/SigningnterceptorBuilderTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/apache/interceptor/SigningnterceptorBuilderTest.java
@@ -1,0 +1,42 @@
+package com.adaptris.aws.apache.interceptor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import org.apache.http.HttpRequestInterceptor;
+import org.junit.Test;
+import com.adaptris.aws.AWSCredentialsProviderBuilder;
+import com.adaptris.aws.StaticCredentialsBuilder;
+import com.adaptris.aws.apache.interceptor.ApacheSigningInterceptor;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.http.AWSRequestSigningApacheInterceptor;
+
+public class SigningnterceptorBuilderTest {
+
+  @Test
+  public void testBuild() {
+    ApacheSigningInterceptor builder =
+        new ApacheSigningInterceptor().withRegion("region").withService("service")
+            .withCredentials(new StaticCredentialsBuilder());
+    HttpRequestInterceptor interceptor = builder.build();
+    assertNotNull(interceptor);
+    assertEquals(AWSRequestSigningApacheInterceptor.class, interceptor.getClass());
+    
+  }
+
+  @Test(expected=Exception.class)
+  public void testBuild_Exception() {
+    ApacheSigningInterceptor builder =
+        new ApacheSigningInterceptor().withRegion("region").withService("service")
+            .withCredentials(new FailingCredentialsBuilder());
+    HttpRequestInterceptor interceptor = builder.build();   
+  }
+
+  private class FailingCredentialsBuilder implements AWSCredentialsProviderBuilder {
+
+    @Override
+    public AWSCredentialsProvider build() throws Exception {
+      throw new Exception();
+    }
+    
+  }
+}


### PR DESCRIPTION
## Motivation

This replaces https://github.com/adaptris/interlok-aws/pull/403 but the motivations etc. are still the same. 

In order to support AWS Managed ElasticSearch requests have to be signed :  

c.f. https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-request-signing.htm

https://github.com/adaptris/interlok-elastic/pull/64 enables interceptors to be configured on the high level rest client.

## Modification

- Include a copy of AWSRequestSigningApacheInterceptor from the awslabs github (https://github.com/awslabs/aws-request-signing-apache-interceptor/)
- Add an ElasticSigningInterceptorBuilder that implements the appropriate interface from interlok-apache-http
- Abuse the lombok.Generated annotation so that jacoco ignores the actual interceptor completely since it's not actively maintained by us.

## Result

New configurable request interceptor that's configurable if you need to target AWS Elasticsearch.

## Testing

Need to test against AWS elastic.
