### PR TITLE
INTERLOK-3247 Use RemoteBlobIterableImpl to lazily iterate over S3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ ext {
   slf4jVersion = '1.7.30'
   awsSDKVersion = '1.11.789'
   log4j2Version = '2.13.2'
+  mockitoVersion = '3.3.3'
 }
 
 if (JavaVersion.current().isJava8Compatible()) {

--- a/interlok-aws-common/build.gradle
+++ b/interlok-aws-common/build.gradle
@@ -57,6 +57,8 @@ publishing {
             properties.appendNode("target", "3.3.0+")
             properties.appendNode("tags", "aws")
             properties.appendNode("license", "false")
+            properties.appendNode("readme", "https://github.com/adaptris/interlok-aws/raw/develop/README.md")
+            properties.appendNode("repository", "https://github.com/adaptris/interlok-aws")
           }
       }
   }

--- a/interlok-aws-kinesis/build.gradle
+++ b/interlok-aws-kinesis/build.gradle
@@ -76,7 +76,9 @@ publishing {
             properties.appendNode("target", "3.9.1+")
             properties.appendNode("tags", "aws,kinesis")
             properties.appendNode("license", "false")
-          }
+            properties.appendNode("readme", "https://github.com/adaptris/interlok-aws/raw/develop/README.md")
+            properties.appendNode("repository", "https://github.com/adaptris/interlok-aws")
+       }
       }
   }
   repositories {

--- a/interlok-aws-s3/build.gradle
+++ b/interlok-aws-s3/build.gradle
@@ -8,11 +8,11 @@ ext {
 
 // In this section you declare the dependencies for your production and test code
 dependencies {
-    compile "com.amazonaws:aws-java-sdk-s3:$awsSDKVersion"
+  compile ("com.amazonaws:aws-java-sdk-s3:$awsSDKVersion")
+  compile project(':interlok-aws-common')
 
-    compile project(':interlok-aws-common')
-
-    testCompile 'org.mockito:mockito-all:1.10.19'
+  testCompile ("org.mockito:mockito-core:$mockitoVersion")
+  testCompile ("org.mockito:mockito-inline:$mockitoVersion")
 }
 
 

--- a/interlok-aws-s3/build.gradle
+++ b/interlok-aws-s3/build.gradle
@@ -62,6 +62,8 @@ publishing {
             properties.appendNode("target", "3.3.0+")
             properties.appendNode("tags", "aws,s3")
             properties.appendNode("license", "false")
+            properties.appendNode("readme", "https://github.com/adaptris/interlok-aws/raw/develop/README.md")
+            properties.appendNode("repository", "https://github.com/adaptris/interlok-aws")
           }
       }
   }

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/CheckFileExistsOperation.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/CheckFileExistsOperation.java
@@ -23,6 +23,7 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.services.exception.ExceptionHandlingServiceWrapper;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.NoArgsConstructor;
 
 /**
  * Check an exists in S3 and throw an exception if it doesn't.
@@ -39,17 +40,16 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @ComponentProfile(summary = "Check a file exists in S3, throws exception if it doesn't",
     since = "3.8.4")
 @XStreamAlias("amazon-s3-check-file-exists")
-@DisplayOrder(order ={ "bucketName", "key"})
-public class CheckFileExistsOperation extends S3OperationImpl {
+@DisplayOrder(order ={ "bucket", "objectName", "bucketName", "key"})
+@NoArgsConstructor
+public class CheckFileExistsOperation extends ObjectOperationImpl {
 
-  public CheckFileExistsOperation() {
-  }
 
   @Override
   public void execute(ClientWrapper wrapper, AdaptrisMessage msg) throws Exception {
     AmazonS3Client s3 = wrapper.amazonClient();
-    String bucket = getBucketName().extract(msg);
-    String key = getKey().extract(msg);
+    String bucket = s3Bucket(msg);
+    String key = s3ObjectKey(msg);
     if (!s3.doesObjectExist(bucket, key)) {      
       throw new Exception(String.format("[%s:%s] does not exist", bucket, key));
     } else {

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/CopyOperation.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/CopyOperation.java
@@ -1,42 +1,42 @@
 /*
-    Copyright 2018 Adaptris
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
+ * Copyright 2018 Adaptris
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 
 package com.adaptris.aws.s3;
 
 import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-
-import org.apache.http.util.Args;
-
+import org.apache.commons.lang3.ObjectUtils;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.interlok.InterlokException;
 import com.adaptris.interlok.config.DataInputParameter;
-import com.adaptris.interlok.types.InterlokMessage;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * Copy an object from S3 to another object
  * 
  * <p>
- * Uses {@link AmazonS3Client#copyObject(String, String, String, String)} using only the default behaviour.
+ * Uses {@link AmazonS3Client#copyObject(String, String, String, String)} using only the default
+ * behaviour.
  * </p>
  * 
  * @config amazon-s3-copy
@@ -44,69 +44,113 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @AdapterComponent
 @ComponentProfile(summary = "Copy an object in S3 to another Object")
 @XStreamAlias("amazon-s3-copy")
-@DisplayOrder(order ={ "bucketName", "key", "destinationBucketName", "destinationKey"})
-public class CopyOperation extends S3OperationImpl {
+@DisplayOrder(order = {"bucket", "objectName", "destinationBucket", "destinationObjectName",
+    "bucketName", "key", "destinationBucketName", "destinationKey"})
+@NoArgsConstructor
+public class CopyOperation extends ObjectOperationImpl {
+  private transient boolean bucketNameWarningLogged = false;
+  private transient boolean keyNameWarningLogged = false;
 
+  /**
+   * The destination bucket.
+   * <p>
+   * If not explictly configured, then we use the bucket name instead making the assumption it's a
+   * copy within the same bucket.
+   * </p>
+   */
   @Valid
+  @Getter
+  @Setter
+  @Deprecated
+  @Removal(version = "3.12.0", message = "Use an expression based bucket instead")
   private DataInputParameter<String> destinationBucketName;
-  @NotNull
+  /**
+   * The destination object.
+   */
   @Valid
+  @Getter
+  @Setter  
+  @Deprecated
+  @Removal(version = "3.12.0", message = "Use an expression based key instead")
   private DataInputParameter<String> destinationKey;
+  
+  /**
+   * The destination bucket.
+   * <p>
+   * If not explictly configured, then we use the bucket name instead making the assumption it's a
+   * copy within the same bucket.
+   * </p>
+   */
+  @Getter
+  @Setter
+  private String destinationBucket;
+  
+  /**
+   * The destination object.
+   */
+  @Getter
+  @Setter
+  // @NotBlank because of deprecated thing.
+  private String destinationObjectName;
 
-  public CopyOperation() {
+
+  @Override
+  public void prepare() throws CoreException {
+    super.prepare();
+    if (getDestinationBucketName() != null) {
+      LoggingHelper.logWarning(bucketNameWarningLogged, () -> bucketNameWarningLogged = true,
+          "[{}] uses [destination-bucket-name], use [destination-bucket] instead",
+          this.getClass().getSimpleName());
+    }
+    if (getDestinationKey() != null) {
+      LoggingHelper.logWarning(keyNameWarningLogged, () -> keyNameWarningLogged = true,
+          "[{}] uses [destination-key], use the alternative string-based expression instead",
+          this.getClass().getSimpleName());
+    }
+    mustHaveEither(getDestinationKey(), getDestinationObjectName());
   }
 
   @Override
   public void execute(ClientWrapper wrapper, AdaptrisMessage msg) throws Exception {
     AmazonS3Client s3 = wrapper.amazonClient();
-    String srcBucket = getBucketName().extract(msg);
-    String srcKey = getKey().extract(msg);
+    String srcBucket = s3Bucket(msg);
+    String srcKey = s3ObjectKey(msg);
     String destBucket = destinationBucket(msg);
-    String destKey = getDestinationKey().extract(msg);
+    String destKey = destinationKey(msg);
     log.trace("Copying [{}:{}] to [{}:{}]", srcBucket, srcKey, destBucket, destKey);
     s3.copyObject(srcBucket, srcKey, destBucket, destKey);
   }
 
-  public DataInputParameter<String> getDestinationBucketName() {
-    return destinationBucketName;
-  }
-
-  /**
-   * Set the destination bucket.
-   * 
-   * @param bucket the bucket, if null, then we use {@link #getBucketName()} as the destination.
-   */
-  public void setDestinationBucketName(DataInputParameter<String> bucket) {
-    this.destinationBucketName = bucket;
-  }
-
+  @Deprecated
   public CopyOperation withDestinationBucketName(DataInputParameter<String> bucket) {
     setDestinationBucketName(bucket);
     return this;
   }
-  
-  private String destinationBucket(InterlokMessage msg) throws InterlokException {
-    if (getDestinationBucketName() == null) {
-      return getBucketName().extract(msg);
-    }
-    return getDestinationBucketName().extract(msg);
-  }
 
-  public DataInputParameter<String> getDestinationKey() {
-    return destinationKey;
-  }
 
-  /**
-   * Set the destination key.
-   * 
-   * @param key the key.
-   */
-  public void setDestinationKey(DataInputParameter<String> key) {
-    this.destinationKey = Args.notNull(key, "destinationKey");
-  }
-
+  @Deprecated
   public CopyOperation withDestinationKey(DataInputParameter<String> key) {
     setDestinationKey(key);
     return this;
+  }
+
+  public CopyOperation withDestinationBucket(String s) {
+    setDestinationBucket(s);
+    return this;
+  }
+
+  public CopyOperation withDestinationObjectName(String s) {
+    setDestinationObjectName(s);
+    return this;
+  }
+
+
+  private String destinationKey(AdaptrisMessage msg) throws InterlokException {
+    return resolve(getDestinationKey(), getDestinationObjectName(), msg);
+  }
+
+  private String destinationBucket(AdaptrisMessage msg) throws InterlokException {
+    return ObjectUtils.defaultIfNull(
+        resolve(getDestinationBucketName(), getDestinationBucket(), msg), s3Bucket(msg));
   }
 }

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/DeleteOperation.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/DeleteOperation.java
@@ -20,10 +20,9 @@ import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.util.ExceptionHelper;
-import com.adaptris.interlok.InterlokException;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.NoArgsConstructor;
 
 /**
  * Delete an object from S3.
@@ -34,17 +33,15 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @AdapterComponent
 @ComponentProfile(summary = "Delete an object from S3")
 @XStreamAlias("amazon-s3-delete")
-@DisplayOrder(order ={ "bucketName", "key"})
-public class DeleteOperation extends S3OperationImpl {
-
-  public DeleteOperation() {
-  }
+@DisplayOrder(order ={ "bucket", "objectName", "bucketName", "key"})
+@NoArgsConstructor
+public class DeleteOperation extends ObjectOperationImpl {
 
   @Override
   public void execute(ClientWrapper wrapper, AdaptrisMessage msg) throws Exception {
     AmazonS3Client s3 = wrapper.amazonClient();
-    String bucket = getBucketName().extract(msg);
-    String key = getKey().extract(msg);
+    String bucket = s3Bucket(msg);
+    String key = s3ObjectKey(msg);
     log.trace("Deleting [{}:{}]", bucket, key);
     s3.deleteObject(bucket, key);
   }

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/GetTagOperation.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/GetTagOperation.java
@@ -28,6 +28,7 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.GetObjectTaggingRequest;
 import com.amazonaws.services.s3.model.Tag;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.NoArgsConstructor;
 
 /**
  * Get tags associated with a S3 Object
@@ -41,17 +42,15 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @AdapterComponent
 @ComponentProfile(summary = "Get tags associated with an object in S3", since = "3.8.4")
 @XStreamAlias("amazon-s3-tag-get")
-@DisplayOrder(order = {"bucketName", "key", "tagMetadataFilter"})
+@DisplayOrder(order = {"bucket", "objectName", "bucketName", "key", "tagMetadataFilter"})
+@NoArgsConstructor
 public class GetTagOperation extends TagOperation {
-
-  public GetTagOperation() {
-  }
 
   @Override
   public void execute(ClientWrapper wrapper, AdaptrisMessage msg) throws Exception {
     AmazonS3Client s3 = wrapper.amazonClient();
-    String srcBucket = getBucketName().extract(msg);
-    String srcKey = getKey().extract(msg);
+    String srcBucket = s3Bucket(msg);
+    String srcKey = s3ObjectKey(msg);
     log.trace("Getting tags for [{}:{}]", srcBucket, srcKey);
     GetObjectTaggingRequest req = new GetObjectTaggingRequest(srcBucket, srcKey);
     msg.setMetadata(filterTags(s3.getObjectTagging(req).getTagSet()));    

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/ObjectOperationImpl.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/ObjectOperationImpl.java
@@ -1,0 +1,55 @@
+package com.adaptris.aws.s3;
+
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.interlok.InterlokException;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Operation on a single S3 Object.
+ * 
+ * <p>
+ * This was introduced to demarcate operations that do work on the bucket as a whole as opposed to a
+ * single S3 Object in the bucket.
+ * </p>
+ * 
+ * @since 3.10.2
+ */
+@NoArgsConstructor
+@SuppressWarnings("deprecation")
+public abstract class ObjectOperationImpl extends S3OperationImpl {
+
+  /**
+   * The Object in S3 that this operation will target.
+   * <p>
+   * Generally this is the full key to the object in the bucket.
+   * </p>
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(expression = true)
+  private String objectName;
+
+
+  @Override
+  public void prepare() throws CoreException {
+    super.prepare();
+    mustHaveEither(getKey(), getObjectName());
+  }
+
+  public <T extends ObjectOperationImpl> T withObjectName(String b) {
+    setObjectName(b);
+    return (T) this;
+  }
+
+  /**
+   * Get the key representing the S3 Object.
+   * 
+   */
+  protected String s3ObjectKey(AdaptrisMessage msg) throws InterlokException {
+    return resolve(getKey(), getObjectName(), msg);
+  }
+}

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/RemoteBlobIterable.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/RemoteBlobIterable.java
@@ -1,0 +1,64 @@
+package com.adaptris.aws.s3;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+import com.adaptris.interlok.cloud.RemoteBlob;
+import com.adaptris.interlok.cloud.RemoteBlobFilter;
+import com.adaptris.interlok.cloud.RemoteBlobIterableImpl;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+
+class RemoteBlobIterable extends RemoteBlobIterableImpl<S3ObjectSummary> {
+  
+  private AmazonS3Client s3Client = null;
+  private ListObjectsV2Request listRequest = null;
+  private RemoteBlobFilter blobFilter = null;
+  
+  private ListObjectsV2Result currentListing;
+  private Iterator<S3ObjectSummary> currentListingIterator;
+  
+  
+  protected RemoteBlobIterable(AmazonS3Client s3, ListObjectsV2Request request, RemoteBlobFilter filter) {
+    this.s3Client = s3;
+    this.listRequest = request;
+    this.blobFilter = filter;
+  }
+    
+  protected Optional<S3ObjectSummary> nextStorageItem() throws NoSuchElementException {
+    if (!currentListingIterator.hasNext()) {
+      advanceToNextPage();
+    }
+    return Optional.ofNullable(currentListingIterator.next());
+  }
+  
+  private void advanceToNextPage() throws NoSuchElementException {
+    if (!currentListing.isTruncated()) {
+      // it's not truncated so there's nothing else to get
+      throw new NoSuchElementException();
+    }
+    String token = currentListing.getNextContinuationToken();
+    listRequest.setContinuationToken(token);
+    currentListing = s3Client.listObjectsV2(listRequest);
+    currentListingIterator = currentListing.getObjectSummaries().iterator();
+  }
+  
+  protected Optional<RemoteBlob> accept(S3ObjectSummary summary) {
+    String bucket = StringUtils.defaultIfEmpty(summary.getBucketName(), listRequest.getBucketName());
+    RemoteBlob blob = new RemoteBlob.Builder().setBucket(bucket).setLastModified(summary.getLastModified().getTime())
+        .setName(summary.getKey()).setSize(summary.getSize()).build();
+    if (blobFilter.accept(blob)) {
+      return Optional.of(blob);
+    }
+    return Optional.empty();   
+  }
+  
+  @Override
+  protected void iteratorInit() {
+    currentListing = s3Client.listObjectsV2(listRequest);
+    currentListingIterator = currentListing.getObjectSummaries().iterator();    
+  }
+}

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3BucketList.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3BucketList.java
@@ -120,7 +120,7 @@ public class S3BucketList extends ServiceImp implements DynamicPollingTemplate.T
           "[{}] uses [page-results], this is ignored", LoggingHelper.friendlyName(this));
     }
     if (getKey() != null) {
-      LoggingHelper.logWarning(keyWarningLogged, () -> pageWarningLogged = true,
+      LoggingHelper.logWarning(keyWarningLogged, () -> keyWarningLogged = true,
           "[{}] uses [key], use [use prefix] instead", LoggingHelper.friendlyName(this));
     }
   }

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3GetOperation.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3GetOperation.java
@@ -1,45 +1,58 @@
 /*
-    Copyright 2018 Adaptris
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
+ * Copyright 2018 Adaptris
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 
 package com.adaptris.aws.s3;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-
 import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.common.InputStreamWithEncoding;
 import com.adaptris.core.common.PayloadStreamOutputParameter;
-import com.adaptris.interlok.InterlokException;
 import com.adaptris.interlok.config.DataOutputParameter;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
- * Get an object from S3 and store the contents of the object either in the message payload or metadata.
+ * Get an object from S3 and store the contents of the object either in the message payload or
+ * metadata.
  * 
  * @author gdries
  * @config amazon-s3-get
  */
 @XStreamAlias("amazon-s3-get")
-@DisplayOrder(order = {"bucketName", "key", "responseBody", "userMetadataFilter"})
+@DisplayOrder(
+    order = {"bucket", "objectName", "bucketName", "key", "responseBody", "userMetadataFilter"})
 public class S3GetOperation extends TransferOperation {
 
+  /**
+   * Where to write the contents of the get operation.
+   * <p>
+   * If not explicitly specified then defaults to the payload via
+   * {@link PayloadStreamOutputParameter}.
+   * </p>
+   */
   @NotNull
+  @Getter
+  @Setter
+  @Valid
+  @InputFieldDefault(value = "the payload")
   private DataOutputParameter<InputStreamWithEncoding> responseBody;
 
   public S3GetOperation() {
@@ -49,19 +62,11 @@ public class S3GetOperation extends TransferOperation {
   @Override
   public void execute(ClientWrapper wrapper, AdaptrisMessage msg) throws Exception {
     AmazonS3Client s3 = wrapper.amazonClient();
-    GetObjectRequest request = new GetObjectRequest(getBucketName().extract(msg), getKey().extract(msg));
+    GetObjectRequest request = new GetObjectRequest(s3Bucket(msg), s3ObjectKey(msg));
     log.debug("Getting {} from bucket {}", request.getKey(), request.getBucketName());
     S3Object response = s3.getObject(request);
     log.trace("Object is {} bytes", response.getObjectMetadata().getContentLength());
     getResponseBody().insert(new InputStreamWithEncoding(response.getObjectContent(), null), msg);
     msg.setMetadata(filterUserMetadata(response.getObjectMetadata().getUserMetadata()));
-  }
-
-  public DataOutputParameter<InputStreamWithEncoding> getResponseBody() {
-    return responseBody;
-  }
-
-  public void setResponseBody(DataOutputParameter<InputStreamWithEncoding> responseBody) {
-    this.responseBody = responseBody;
   }
 }

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3Operation.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3Operation.java
@@ -17,9 +17,10 @@
 package com.adaptris.aws.s3;
 
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.interlok.InterlokException;
+import com.adaptris.core.ComponentLifecycle;
+import com.adaptris.core.ComponentLifecycleExtension;
 
-public interface S3Operation {
+public interface S3Operation extends ComponentLifecycleExtension {
 
   void execute(ClientWrapper wrapper, AdaptrisMessage msg) throws Exception;
   

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3OperationImpl.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3OperationImpl.java
@@ -1,74 +1,114 @@
 /*
-    Copyright 2018 Adaptris
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-*/
+ * Copyright 2018 Adaptris
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 
 package com.adaptris.aws.s3;
 
 import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-
-import org.apache.http.util.Args;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.annotation.Removal;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.util.LoggingHelper;
+import com.adaptris.interlok.InterlokException;
 import com.adaptris.interlok.config.DataInputParameter;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * Abstract base class for S3 Operations.
  * 
- * @author lchan
  *
  */
+@NoArgsConstructor
 public abstract class S3OperationImpl implements S3Operation {
   protected transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
 
+  private transient boolean bucketNameWarningLogged = false;
+  private transient boolean keyNameWarningLogged = false;
 
-  @NotNull
+  @AdvancedConfig(rare = true)
+  @Getter
+  @Setter
   @Valid
+  @Deprecated
+  @Removal(version = "3.12.0", message = "Use an expression based bucket instead")
   private DataInputParameter<String> bucketName;
-  @NotNull
+  @AdvancedConfig(rare = true)
+  @Getter
+  @Setter
   @Valid
+  @Deprecated
+  @Removal(version = "3.12.0", message = "Use an expression based blob-name/prefix instead")
   private DataInputParameter<String> key;
 
-  public S3OperationImpl() {
-  }
+  @Getter
+  @Setter
+  @InputFieldHint(expression = true)
+  private String bucket;
 
-  public DataInputParameter<String> getKey() {
-    return key;
-  }
-
-  public void setKey(DataInputParameter<String> key) {
-    this.key = Args.notNull(key, "key");
-  }
 
   public <T extends S3OperationImpl> T withKey(DataInputParameter<String> key) {
     setKey(key);
     return (T) this;
-  }
-  
-  public DataInputParameter<String> getBucketName() {
-    return bucketName;
-  }
-
-  public void setBucketName(DataInputParameter<String> bucketName) {
-    this.bucketName = Args.notNull(bucketName, "bucketName");
   }
 
   public <T extends S3OperationImpl> T withBucketName(DataInputParameter<String> key) {
     setBucketName(key);
     return (T) this;
   }
-  
+
+  public <T extends S3OperationImpl> T withBucket(String b) {
+    setBucket(b);
+    return (T) this;
+  }
+
+  @Override
+  public void prepare() throws CoreException {
+    if (getBucketName() != null) {
+      LoggingHelper.logWarning(bucketNameWarningLogged, () -> bucketNameWarningLogged = true,
+          "[{}] uses [bucket-name], use [bucket] instead", this.getClass().getSimpleName());
+    }
+    if (getKey() != null) {
+      LoggingHelper.logWarning(keyNameWarningLogged, () -> keyNameWarningLogged = true,
+          "[{}] uses [key], use the alternative string-based expression instead",
+          this.getClass().getSimpleName());
+    }
+    mustHaveEither(getBucketName(), getBucket());
+  }
+
+  protected static void mustHaveEither(DataInputParameter<String> legacy, String expression) {
+    if (BooleanUtils.and(new boolean[] {legacy == null, StringUtils.isBlank(expression)})) {
+      throw new IllegalArgumentException("both data-input param and expression are empty");
+    }
+  }
+
+  protected String s3Bucket(AdaptrisMessage msg) throws InterlokException {
+    return resolve(getBucketName(), getBucket(), msg);
+  }
+
+  protected static String resolve(DataInputParameter<String> legacy, String expression,
+      AdaptrisMessage msg) throws InterlokException {
+    String result = msg.resolve(expression, true);
+    if (legacy != null) {
+      result = legacy.extract(msg);
+    }
+    return result;
+  }
 }

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3Service.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3Service.java
@@ -28,6 +28,7 @@ import com.adaptris.core.ServiceException;
 import com.adaptris.core.util.Args;
 import com.adaptris.core.util.ExceptionHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.NoArgsConstructor;
 
 /**
  * 
@@ -38,13 +39,12 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @ComponentProfile(summary = "Amazon S3 Service", recommended={AmazonS3Connection.class})
 @XStreamAlias("amazon-s3-service")
 @DisplayOrder(order = {"connection", "operation"})
+@NoArgsConstructor
 public class S3Service extends S3ServiceImpl {
 
   @NotNull
   @Valid
   private S3Operation operation;
-
-  public S3Service() {}
 
   public S3Service(AdaptrisConnection c, S3Operation op) {
     this();
@@ -62,14 +62,12 @@ public class S3Service extends S3ServiceImpl {
   }
 
   @Override
-  protected void initService() throws CoreException {
-    try {
-      Args.notNull(getOperation(), "operation");
-      super.initService();
-    } catch (Exception e) {
-      throw ExceptionHelper.wrapCoreException(e);
-    }
+  public void prepare() throws CoreException {
+    Args.notNull(getOperation(), "operation");
+    super.prepare();
+    getOperation().prepare();
   }
+ 
 
   public S3Operation getOperation() {
     return operation;

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3ServiceImpl.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3ServiceImpl.java
@@ -17,11 +17,16 @@
 package com.adaptris.aws.s3;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import com.adaptris.core.AdaptrisConnection;
 import com.adaptris.core.ConnectedService;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceImp;
 import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.interlok.util.Args;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
 
 /**
  * Abstract implemention of {@link S3Service}
@@ -29,7 +34,15 @@ import com.adaptris.core.util.LifecycleHelper;
  */
 public abstract class S3ServiceImpl extends ServiceImp implements ConnectedService {
 
+  /**
+   * Set the connection to use to connect to S3.
+   * 
+   */
   @Valid
+  @Getter
+  @Setter
+  @NotNull
+  @NonNull
   private AdaptrisConnection connection;
   
   public S3ServiceImpl() {
@@ -37,6 +50,7 @@ public abstract class S3ServiceImpl extends ServiceImp implements ConnectedServi
 
   @Override
   public void prepare() throws CoreException {
+    Args.notNull(getConnection(), "connection");
     LifecycleHelper.prepare(getConnection());
   }
   
@@ -60,20 +74,5 @@ public abstract class S3ServiceImpl extends ServiceImp implements ConnectedServi
   @Override
   protected void closeService() {
     LifecycleHelper.close(getConnection());
-  }
-
-  @Override
-  public AdaptrisConnection getConnection() {
-    return connection;
-  }
-
-  /**
-   * Set the connection to use to connect to S3.
-   * 
-   * @param connection the connection.
-   */
-  @Override
-  public void setConnection(AdaptrisConnection connection) {
-    this.connection = connection;
   }
 }

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/TagOperation.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/TagOperation.java
@@ -31,7 +31,7 @@ import com.amazonaws.services.s3.model.ObjectTagging;
 import com.amazonaws.services.s3.model.SetObjectTaggingRequest;
 import com.amazonaws.services.s3.model.Tag;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-
+import lombok.NoArgsConstructor;
 import javax.validation.Valid;
 
 import org.apache.commons.lang3.ObjectUtils;
@@ -51,20 +51,18 @@ import java.util.List;
 @AdapterComponent
 @ComponentProfile(summary = "Tag an object in S3")
 @XStreamAlias("amazon-s3-tag")
-@DisplayOrder(order ={ "bucketName", "key", "tagMetadataFilter"})
-public class TagOperation extends S3OperationImpl {
+@DisplayOrder(order ={ "bucket", "objectName", "bucketName", "key", "tagMetadataFilter"})
+@NoArgsConstructor
+public class TagOperation extends ObjectOperationImpl {
 
   @Valid
   private MetadataFilter tagMetadataFilter;
 
-  public TagOperation() {
-  }
-
   @Override
   public void execute(ClientWrapper wrapper, AdaptrisMessage msg) throws Exception {
     AmazonS3Client s3 = wrapper.amazonClient();
-    String srcBucket = getBucketName().extract(msg);
-    String srcKey = getKey().extract(msg);
+    String srcBucket = s3Bucket(msg);
+    String srcKey = s3ObjectKey(msg);
     List<Tag> tags = filterTagMetadata(msg);
     if (!tags.isEmpty()) {
       log.trace("Tagging [{}:{}]", srcBucket, srcKey);

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/TransferOperation.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/TransferOperation.java
@@ -36,7 +36,7 @@ import com.adaptris.core.metadata.RemoveAllMetadataFilter;
  * 
  *
  */
-public abstract class TransferOperation extends S3OperationImpl {
+public abstract class TransferOperation extends ObjectOperationImpl {
 
   @Valid
   @AdvancedConfig

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/UploadOperation.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/UploadOperation.java
@@ -48,7 +48,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @AdapterComponent
 @ComponentProfile(summary = "Amazon S3 Upload using Transfer Manager")
 @XStreamAlias("amazon-s3-upload")
-@DisplayOrder(order = {"bucketName", "key", "userMetadataFilter", "objectMetadata"})
+@DisplayOrder(order = {"bucket", "objectName", "bucketName", "key", "userMetadataFilter", "objectMetadata"})
 public class UploadOperation extends TransferOperation {
 
   private transient ManagedThreadFactory threadFactory = new ManagedThreadFactory();
@@ -60,8 +60,8 @@ public class UploadOperation extends TransferOperation {
   @Override
   public void execute(ClientWrapper wrapper, AdaptrisMessage msg) throws Exception {
     TransferManager tm = wrapper.transferManager();
-    String bucketName = getBucketName().extract(msg);
-    String key = getKey().extract(msg);
+    String bucketName = s3Bucket(msg);
+    String key = s3ObjectKey(msg);
     ObjectMetadata s3meta = new ObjectMetadata();
     s3meta.setContentLength(msg.getSize());
     if(StringUtils.isNotEmpty(msg.getContentEncoding())) {

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ContentDisposition.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ContentDisposition.java
@@ -17,12 +17,10 @@
 package com.adaptris.aws.s3.meta;
 
 import javax.validation.constraints.NotNull;
-
-import org.apache.commons.lang3.StringUtils;
-
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
+import com.adaptris.interlok.util.Args;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
@@ -36,9 +34,7 @@ public class S3ContentDisposition extends S3ObjectMetadata {
 
   @Override
   public void apply(AdaptrisMessage msg, ObjectMetadata meta) throws ServiceException {
-    if(StringUtils.isEmpty(getContentDisposition())) {
-      throw new ServiceException("Content Disposition must be specified");
-    }
+    Args.notNull(getContentDisposition(), "content-disposition");
     meta.setContentDisposition(msg.resolve(getContentDisposition()));
   }
 

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ContentEncoding.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ContentEncoding.java
@@ -16,14 +16,13 @@
 
 package com.adaptris.aws.s3.meta;
 
+import javax.validation.constraints.NotNull;
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
+import com.adaptris.interlok.util.Args;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-import org.apache.commons.lang3.StringUtils;
-
-import javax.validation.constraints.NotNull;
 
 @XStreamAlias("s3-content-encoding")
 // @XStreamConverter(value = ToAttributedValueConverter.class, strings = { "contentEncoding" })
@@ -35,9 +34,7 @@ public class S3ContentEncoding extends S3ObjectMetadata {
 
   @Override
   public void apply(AdaptrisMessage msg, ObjectMetadata meta) throws ServiceException {
-    if(StringUtils.isEmpty(getContentEncoding())) {
-      throw new ServiceException("Content Encoding must be specified");
-    }
+    Args.notNull(getContentEncoding(), "content-encoding");
     meta.setContentEncoding(msg.resolve(getContentEncoding()));
   }
 

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ContentLanguage.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ContentLanguage.java
@@ -17,12 +17,10 @@
 package com.adaptris.aws.s3.meta;
 
 import javax.validation.constraints.NotNull;
-
-import org.apache.commons.lang3.StringUtils;
-
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
+import com.adaptris.interlok.util.Args;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
@@ -36,9 +34,7 @@ public class S3ContentLanguage extends S3ObjectMetadata {
   
   @Override
   public void apply(AdaptrisMessage msg, ObjectMetadata meta) throws ServiceException {
-    if(StringUtils.isEmpty(getContentLanguage())) {
-      throw new ServiceException("Content Language must be specified");
-    }
+    Args.notNull(getContentLanguage(), "content-language");
     meta.setContentLanguage(msg.resolve(getContentLanguage()));
   }
 

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ContentType.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ContentType.java
@@ -17,12 +17,10 @@
 package com.adaptris.aws.s3.meta;
 
 import javax.validation.constraints.NotNull;
-
-import org.apache.commons.lang3.StringUtils;
-
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
+import com.adaptris.interlok.util.Args;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
@@ -36,9 +34,7 @@ public class S3ContentType extends S3ObjectMetadata {
 
   @Override
   public void apply(AdaptrisMessage msg, ObjectMetadata meta) throws ServiceException {
-    if(StringUtils.isEmpty(getContentType())) {
-      throw new ServiceException("Content Type must be specified");
-    }
+    Args.notNull(getContentType(), "content-type");
     meta.setContentType(msg.resolve(getContentType()));
   }
 

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ExpirationTimeRuleId.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ExpirationTimeRuleId.java
@@ -17,12 +17,10 @@
 package com.adaptris.aws.s3.meta;
 
 import javax.validation.constraints.NotNull;
-
-import org.apache.commons.lang3.StringUtils;
-
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
+import com.adaptris.interlok.util.Args;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
@@ -36,9 +34,7 @@ public class S3ExpirationTimeRuleId extends S3ObjectMetadata {
   
   @Override
   public void apply(AdaptrisMessage msg, ObjectMetadata meta) throws ServiceException {
-    if(StringUtils.isEmpty(getExpirationTimeRuleId())) {
-      throw new ServiceException("Expiration Time Rule Id must be specified");
-    }
+    Args.notNull(getExpirationTimeRuleId(), "expiration-rule-id");
     meta.setExpirationTimeRuleId(msg.resolve(getExpirationTimeRuleId()));
   }
 

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3HttpExpiresDate.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3HttpExpiresDate.java
@@ -17,12 +17,11 @@
 package com.adaptris.aws.s3.meta;
 
 import java.util.Calendar;
-
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
+import com.adaptris.interlok.util.Args;
 import com.adaptris.util.TimeInterval;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -36,9 +35,7 @@ public class S3HttpExpiresDate extends S3ObjectMetadata {
   
   @Override
   public void apply(AdaptrisMessage msg, ObjectMetadata meta) throws ServiceException {
-    if(getTimeToLive() == null) {
-      throw new ServiceException("Time to Live must be specified");
-    }
+    Args.notNull(getTimeToLive(), "time-to-live");
     Calendar cal = Calendar.getInstance();
     cal.add(Calendar.MILLISECOND, (int)getTimeToLive().toMilliseconds());
     meta.setHttpExpiresDate(cal.getTime());

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ServerSideEncryption.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ServerSideEncryption.java
@@ -17,13 +17,15 @@
 package com.adaptris.aws.s3.meta;
 
 import javax.validation.constraints.NotNull;
-
+import org.apache.commons.lang3.BooleanUtils;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisMessage;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Enable S3 Server Side Encryption with AWS managed keys
@@ -46,21 +48,23 @@ public class S3ServerSideEncryption extends S3ObjectMetadata {
   }
 
   @AdvancedConfig
-  @InputFieldDefault("true")
-  private boolean enabled = true;
+  @InputFieldDefault(value = "true")
+  @Getter
+  @Setter
+  private Boolean enabled;
   
   @NotNull
   @AutoPopulated
+  @AdvancedConfig
   private Algorithm algorithm;
   
   public S3ServerSideEncryption() {
-    setEnabled(true);
     setAlgorithm(Algorithm.AES_256);
   }
 
   @Override
   public void apply(AdaptrisMessage msg, ObjectMetadata meta) {
-    if(getEnabled()) {
+    if (enabled()) {
       getAlgorithm().apply(meta);
     }
   }
@@ -78,12 +82,8 @@ public class S3ServerSideEncryption extends S3ObjectMetadata {
     this.algorithm = algorithm;
   }
 
-  public boolean getEnabled() {
-    return enabled;
-  }
-
-  public void setEnabled(boolean enabled) {
-    this.enabled = enabled;
+  private boolean enabled() {
+    return BooleanUtils.toBooleanDefaultIfNull(getEnabled(), true);
   }
 
 }

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/BucketListTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/BucketListTest.java
@@ -157,6 +157,7 @@ public class BucketListTest {
     List<S3ObjectSummary> summaries2 = new ArrayList<>(Collections.singletonList(
         createSummary("srcBucket", "srcKeyPrefix/file2.csv")));
     Mockito.when(listing2.getObjectSummaries()).thenReturn(summaries2);
+    Mockito.when(listing2.isTruncated()).thenReturn(false);
 
     ArgumentCaptor<ListObjectsV2Request> argument = ArgumentCaptor.forClass(ListObjectsV2Request.class);
 
@@ -174,7 +175,8 @@ public class BucketListTest {
 
     assertEquals("srcBucket", capturedRequests.get(0).getBucketName());
     assertEquals("srcKeyPrefix", capturedRequests.get(0).getPrefix());
-    assertNull(capturedRequests.get(0).getContinuationToken());
+    // Since we are re-using the same object repeatedly, this is probably set to "abc123"
+    // assertNull(capturedRequests.get(0).getContinuationToken());
     assertNotNull(capturedRequests.get(0).getMaxKeys());
     assertEquals(Optional.of(2), Optional.ofNullable(capturedRequests.get(0).getMaxKeys()));
 

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/BucketListTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/BucketListTest.java
@@ -27,6 +27,7 @@ import com.amazonaws.services.s3.model.ListObjectsV2Request;
 import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 
+@SuppressWarnings("deprecation")
 public class BucketListTest {
 
   @Test
@@ -43,8 +44,10 @@ public class BucketListTest {
     ArgumentCaptor<ListObjectsV2Request> argument = ArgumentCaptor.forClass(ListObjectsV2Request.class);
     Mockito.when(client.listObjectsV2(argument.capture())).thenReturn(listing);
 
+    // for coverage, we should use withPrefix().
     S3BucketList bucket =
-        new S3BucketList().withConnection(mockConnection).withBucket("srcBucket").withKey("srcKeyPrefix").withOutputStyle(null);
+        new S3BucketList().withConnection(mockConnection).withBucket("srcBucket")
+            .withKey("srcKeyPrefix").withOutputStyle(null);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     ServiceCase.execute(bucket, msg);
 
@@ -74,7 +77,8 @@ public class BucketListTest {
         new RemoteBlobFilterWrapper().withFilterExpression(".*\\.json").withFilterImp(RegexFileFilter.class.getCanonicalName());
 
     S3BucketList bucket =
-        new S3BucketList().withConnection(mockConnection).withBucket("srcBucket").withKey("srcKeyPrefix").withFilter(filter);
+        new S3BucketList().withConnection(mockConnection).withBucket("srcBucket")
+            .withPrefix("srcKeyPrefix").withFilter(filter);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     ServiceCase.execute(bucket, msg);
 
@@ -96,7 +100,8 @@ public class BucketListTest {
     BlobListRenderer brokenRender = Mockito.mock(BlobListRenderer.class);
     Mockito.doThrow(new RuntimeException()).when(brokenRender).render(any(), any());
     S3BucketList bucket =
-        new S3BucketList().withConnection(mockConnection).withBucket("srcBucket").withKey("srcKeyPrefix")
+        new S3BucketList().withConnection(mockConnection).withBucket("srcBucket")
+            .withPrefix("srcKeyPrefix")
             .withOutputStyle(brokenRender);
 
     ListObjectsV2Result listing = Mockito.mock(ListObjectsV2Result.class);
@@ -124,7 +129,8 @@ public class BucketListTest {
     Mockito.when(client.listObjectsV2(argument.capture())).thenReturn(listing);
 
     S3BucketList bucket =
-        new S3BucketList().withConnection(mockConnection).withBucket("srcBucket").withKey("srcKeyPrefix").withMaxKeys(2).withOutputStyle(null);
+        new S3BucketList().withConnection(mockConnection).withBucket("srcBucket")
+            .withPrefix("srcKeyPrefix").withMaxKeys(2).withOutputStyle(null);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     ServiceCase.execute(bucket, msg);
 
@@ -164,8 +170,9 @@ public class BucketListTest {
     Mockito.when(client.listObjectsV2(argument.capture())).thenReturn(listing, listing2);
 
     S3BucketList bucket =
-        new S3BucketList().withConnection(mockConnection).withBucket("srcBucket").withKey("srcKeyPrefix").withMaxKeys(2)
-            .withOutputStyle(null);
+        new S3BucketList().withConnection(mockConnection).withPageResults(true)
+            .withPrefix("srcKeyPrefix").withMaxKeys(2)
+            .withOutputStyle(null).withBucket("srcBucket");
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     ServiceCase.execute(bucket, msg);
 

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/BucketListTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/BucketListTest.java
@@ -4,7 +4,7 @@ import static com.adaptris.aws.s3.MockedOperationTest.createSummary;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -165,7 +165,7 @@ public class BucketListTest {
 
     S3BucketList bucket =
         new S3BucketList().withConnection(mockConnection).withBucket("srcBucket").withKey("srcKeyPrefix").withMaxKeys(2)
-            .withPageResults(true).withOutputStyle(null);
+            .withOutputStyle(null);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
     ServiceCase.execute(bucket, msg);
 

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/CreateBucketOperation.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/CreateBucketOperation.java
@@ -16,20 +16,12 @@
 
 package com.adaptris.aws.s3;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-
-import org.apache.http.util.Args;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.core.util.ExceptionHelper;
-import com.adaptris.interlok.InterlokException;
-import com.adaptris.interlok.config.DataInputParameter;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
@@ -41,14 +33,10 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @AdapterComponent
 @ComponentProfile(summary = "Create a bucket in S3")
 @XStreamAlias("amazon-s3-create-bucket")
-@DisplayOrder(order ={ "bucketName"})
-public class CreateBucketOperation implements S3Operation {
+@DisplayOrder(order = {"bucket", "bucketName"})
+public class CreateBucketOperation extends S3OperationImpl {
 
   protected transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
-
-  @NotNull
-  @Valid
-  private DataInputParameter<String> bucketName;
   
   public CreateBucketOperation() {
   }
@@ -56,23 +44,8 @@ public class CreateBucketOperation implements S3Operation {
   @Override
   public void execute(ClientWrapper wrapper, AdaptrisMessage msg) throws Exception {
     AmazonS3Client s3 = wrapper.amazonClient();
-    String bucket = getBucketName().extract(msg);
+    String bucket = s3Bucket(msg);
     log.trace("Creating Bucket [{}]", bucket);
     s3.createBucket(bucket);
   }
-
-  
-  public DataInputParameter<String> getBucketName() {
-    return bucketName;
-  }
-
-  public void setBucketName(DataInputParameter<String> bucketName) {
-    this.bucketName = Args.notNull(bucketName, "bucketName");
-  }
-
-  public <T extends CreateBucketOperation> T withBucketName(DataInputParameter<String> key) {
-    setBucketName(key);
-    return (T) this;
-  }
-  
 }

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/DeleteBucketOperation.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/DeleteBucketOperation.java
@@ -40,7 +40,7 @@ public class DeleteBucketOperation extends CreateBucketOperation {
   @Override
   public void execute(ClientWrapper wrapper, AdaptrisMessage msg) throws Exception {
     AmazonS3Client s3 = wrapper.amazonClient();
-    String bucket = getBucketName().extract(msg);
+    String bucket = s3Bucket(msg);
     log.trace("Deleting Bucket [{}]", bucket);
     s3.deleteBucket(bucket);
   }

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/MockedOperationTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/MockedOperationTest.java
@@ -3,9 +3,9 @@ package com.adaptris.aws.s3;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyObject;
+import static org.mockito.ArgumentMatchers.anyString;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
@@ -42,10 +42,11 @@ import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.TransferProgress;
 import com.amazonaws.services.s3.transfer.Upload;
 
+@SuppressWarnings("deprecation")
 public class MockedOperationTest {
 
   @Test
-  public void testCopy_NoDestinationBucket() throws Exception {
+  public void testCopy_NoDestinationBucket_Legacy() throws Exception {
     AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
     CopyObjectResult result = new CopyObjectResult();
     Mockito.when(client.copyObject(anyString(), anyString(), anyString(), anyString())).thenReturn(result);    
@@ -55,22 +56,50 @@ public class MockedOperationTest {
         .withBucketName(new ConstantDataInputParameter("bucketName"))
         .withKey(new ConstantDataInputParameter("key"));
     ClientWrapper wrapper = new ClientWrapperImpl(client);    
-    op.execute(wrapper, msg);
+    execute(op, wrapper, msg);
+  }
+
+  @Test
+  public void testCopy_NoDestinationBucket() throws Exception {
+    AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
+    CopyObjectResult result = new CopyObjectResult();
+    Mockito.when(client.copyObject(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(result);
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    CopyOperation op =
+        new CopyOperation().withDestinationObjectName("destKey")
+            .withObjectName("key")
+            .withBucket("bucketName");
+    ClientWrapper wrapper = new ClientWrapperImpl(client);
+    execute(op, wrapper, msg);
+  }
+
+  @Test
+  public void testCopy_Legacy() throws Exception {
+    AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
+    CopyObjectResult result = new CopyObjectResult();
+    Mockito.when(client.copyObject(anyString(), anyString(), anyString(), anyString())).thenReturn(result);    
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    CopyOperation op =
+    new CopyOperation().withDestinationBucketName(new ConstantDataInputParameter("destBucket"))
+        .withDestinationKey(new ConstantDataInputParameter("destKey"))
+        .withBucketName(new ConstantDataInputParameter("srcBucket"))
+        .withKey(new ConstantDataInputParameter("srcKey"));
+    ClientWrapper wrapper = new ClientWrapperImpl(client);    
+    execute(op, wrapper, msg);
   }
 
   @Test
   public void testCopy() throws Exception {
     AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
     CopyObjectResult result = new CopyObjectResult();
-    Mockito.when(client.copyObject(anyString(), anyString(), anyString(), anyString())).thenReturn(result);    
+    Mockito.when(client.copyObject(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn(result);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-    CopyOperation op = new CopyOperation()
-        .withDestinationBucketName(new ConstantDataInputParameter("destBucket"))
-        .withDestinationKey(new ConstantDataInputParameter("destKey"))
-        .withBucketName(new ConstantDataInputParameter("srcBucket"))
-        .withKey(new ConstantDataInputParameter("srcKey"));
-    ClientWrapper wrapper = new ClientWrapperImpl(client);    
-    op.execute(wrapper, msg);
+    CopyOperation op = new CopyOperation().withDestinationBucket("destBucket")
+        .withDestinationObjectName("destKey").withObjectName("key").withBucket("bucketName");
+    ClientWrapper wrapper = new ClientWrapperImpl(client);
+    execute(op, wrapper, msg);
   }
 
   @Test
@@ -82,7 +111,7 @@ public class MockedOperationTest {
         .withBucketName(new ConstantDataInputParameter("bucketName"))
         .withKey(new ConstantDataInputParameter("key"));
     ClientWrapper wrapper = new ClientWrapperImpl(client);    
-    op.execute(wrapper, msg);
+    execute(op, wrapper, msg);
   }
   
   
@@ -102,7 +131,7 @@ public class MockedOperationTest {
         .withBucketName(new ConstantDataInputParameter("srcBucket"))
         .withKey(new ConstantDataInputParameter("srcKey"));
     ClientWrapper wrapper = new ClientWrapperImpl(client);    
-    op.execute(wrapper, msg);
+    execute(op, wrapper, msg);
   }
   
   @Test
@@ -117,7 +146,7 @@ public class MockedOperationTest {
         .withBucketName(new ConstantDataInputParameter("srcBucket"))
         .withKey(new ConstantDataInputParameter("srcKey"));
     ClientWrapper wrapper = new ClientWrapperImpl(client);    
-    tag.execute(wrapper, msg);    
+    execute(tag, wrapper, msg);
   }
 
   @Test
@@ -131,7 +160,7 @@ public class MockedOperationTest {
         .withBucketName(new ConstantDataInputParameter("srcBucket"))
         .withKey(new ConstantDataInputParameter("srcKey"));
     ClientWrapper wrapper = new ClientWrapperImpl(client);    
-    tag.execute(wrapper, msg);    
+    execute(tag, wrapper, msg);
   }
   
   @Test
@@ -160,7 +189,7 @@ public class MockedOperationTest {
         .withBucketName(new ConstantDataInputParameter("srcBucket"))
         .withKey(new ConstantDataInputParameter("srcKey"));
     ClientWrapper wrapper = new ClientWrapperImpl(client, transferManager);    
-    downloader.execute(wrapper, msg);
+    execute(downloader, wrapper, msg);
   }
 
   @Test
@@ -188,7 +217,7 @@ public class MockedOperationTest {
         .withBucketName(new ConstantDataInputParameter("srcBucket"))
         .withKey(new ConstantDataInputParameter("srcKey"));
     ClientWrapper wrapper = new ClientWrapperImpl(client, transferManager);    
-    downloader.execute(wrapper, msg);
+    execute(downloader, wrapper, msg);
   }
   
   @Test
@@ -213,7 +242,7 @@ public class MockedOperationTest {
         .withBucketName(new ConstantDataInputParameter("srcBucket"))
         .withKey(new ConstantDataInputParameter("srcKey"));
     ClientWrapper wrapper = new ClientWrapperImpl(client, transferManager);    
-    uploader.execute(wrapper, msg);
+    execute(uploader, wrapper, msg);
   }
   
   @Test
@@ -238,7 +267,7 @@ public class MockedOperationTest {
         .withBucketName(new ConstantDataInputParameter("srcBucket"))
         .withKey(new ConstantDataInputParameter("srcKey"));
     ClientWrapper wrapper = new ClientWrapperImpl(client, transferManager);    
-    uploader.execute(wrapper, msg);
+    execute(uploader, wrapper, msg);
   }
 
   @Test
@@ -252,13 +281,13 @@ public class MockedOperationTest {
         .withKey(new ConstantDataInputParameter("srcKey"));
     ClientWrapper wrapper = new ClientWrapperImpl(client, transferManager);
     try {
-      checker.execute(wrapper, msg);
+      execute(checker, wrapper, msg);
       fail();
     }
     catch (Exception expcted) {
 
     }
-    checker.execute(wrapper, msg);
+    execute(checker, wrapper, msg);
   }
 
   @Test
@@ -274,7 +303,7 @@ public class MockedOperationTest {
 
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("");
     ClientWrapper wrapper = new ClientWrapperImpl(client, transferManager);
-    getTags.execute(wrapper, msg);
+    execute(getTags, wrapper, msg);
     assertTrue(msg.headersContainsKey("hello"));
     assertEquals("world", msg.getMetadataValue("hello"));
   }
@@ -344,8 +373,14 @@ public class MockedOperationTest {
 
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("");
     ClientWrapper wrapper = new ClientWrapperImpl(client, transferManager);
-    ls.execute(wrapper, msg);
+    execute(ls, wrapper, msg);
     assertEquals("srcKeyPrefix/file.json" + System.lineSeparator(), msg.getContent());
+  }
+
+  private void execute(S3Operation op, ClientWrapper wrapper, AdaptrisMessage msg)
+      throws Exception {
+    op.prepare();
+    op.execute(wrapper, msg);
   }
 
   public static S3ObjectSummary createSummary(String bucket, String key) {

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/MockedOperationTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/MockedOperationTest.java
@@ -320,11 +320,11 @@ public class MockedOperationTest {
     Mockito.when(result.getObjectSummaries()).thenReturn(list);
     Mockito.when(client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(result);
     ListOperation ls = new ListOperation()
-        .withBucketName(new ConstantDataInputParameter("srcBucket")).withKey(new ConstantDataInputParameter("srcKeyPrefix/"));
-
+        .withPrefix("srcKeyPrefix/")
+        .withBucket("srcBucket");
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("");
     ClientWrapper wrapper = new ClientWrapperImpl(client, transferManager);
-    ls.execute(wrapper, msg);
+    execute(ls, wrapper, msg);
     assertEquals(
         "srcKeyPrefix/" + System.lineSeparator() +
         "srcKeyPrefix/file.json" + System.lineSeparator() +
@@ -346,11 +346,12 @@ public class MockedOperationTest {
     Mockito.when(client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(result);
     ListOperation ls = new ListOperation()
         .withFilterSuffix(new ConstantDataInputParameter(".json"))
+        .withPageResults(true)
         .withBucketName(new ConstantDataInputParameter("srcBucket")).withKey(new ConstantDataInputParameter("srcKeyPrefix/"));
 
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("");
     ClientWrapper wrapper = new ClientWrapperImpl(client, transferManager);
-    ls.execute(wrapper, msg);
+    execute(ls, wrapper, msg);
     assertEquals("srcKeyPrefix/file.json" + System.lineSeparator(), msg.getContent());
   }
 
@@ -369,7 +370,8 @@ public class MockedOperationTest {
     RemoteBlobFilterWrapper filter =
         new RemoteBlobFilterWrapper().withFilterExpression(".*\\.json").withFilterImp(RegexFileFilter.class.getCanonicalName());
     ListOperation ls = new ListOperation().withFilter(filter)
-        .withBucketName(new ConstantDataInputParameter("srcBucket")).withKey(new ConstantDataInputParameter("srcKeyPrefix/"));
+        .withPrefix("srcKeyPrefix/")
+        .withBucket("srcBucket");
 
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("");
     ClientWrapper wrapper = new ClientWrapperImpl(client, transferManager);

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/S3ServiceTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/S3ServiceTest.java
@@ -16,7 +16,7 @@
 
 package com.adaptris.aws.s3;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
@@ -30,7 +30,6 @@ import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceCase;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.common.ConstantDataInputParameter;
 import com.adaptris.core.common.PayloadStreamOutputParameter;
 import com.adaptris.core.metadata.NoOpMetadataFilter;
 import com.adaptris.core.metadata.RemoveAllMetadataFilter;
@@ -47,8 +46,8 @@ public class S3ServiceTest extends ServiceCase {
       @Override
       S3Operation build() {
         DownloadOperation op = new DownloadOperation();
-        op.setKey(new ConstantDataInputParameter("s3-key"));
-        op.setBucketName(new ConstantDataInputParameter("s3-bucket"));
+        op.setObjectName("s3-key");
+        op.setBucket("%message{s3-bucket-key}");
         op.setTempDirectory("/path/to/temp/dir/if/required");
         return op;
       }
@@ -58,8 +57,8 @@ public class S3ServiceTest extends ServiceCase {
       @Override
       S3Operation build() {
         S3GetOperation op = new S3GetOperation();
-        op.setKey(new ConstantDataInputParameter("s3-key"));
-        op.setBucketName(new ConstantDataInputParameter("s3-bucket"));
+        op.setObjectName("s3-key");
+        op.setBucket("%message{s3-bucket-key}");
         op.setResponseBody(new PayloadStreamOutputParameter());
         return op;
       }
@@ -68,8 +67,8 @@ public class S3ServiceTest extends ServiceCase {
       @Override
       S3Operation build() {
         UploadOperation op = new UploadOperation();
-        op.setKey(new ConstantDataInputParameter("s3-key"));
-        op.setBucketName(new ConstantDataInputParameter("s3-bucket"));
+        op.setObjectName("s3-key");
+        op.setBucket("%message{s3-bucket-key}");
         op.setUserMetadataFilter(new RemoveAllMetadataFilter());
         S3ContentLanguage type = new S3ContentLanguage();
         type.setContentLanguage("english");
@@ -81,8 +80,8 @@ public class S3ServiceTest extends ServiceCase {
       @Override
       S3Operation build() {
         TagOperation op = new TagOperation();
-        op.setKey(new ConstantDataInputParameter("s3-key"));
-        op.setBucketName(new ConstantDataInputParameter("s3-bucket"));
+        op.setObjectName("s3-key");
+        op.setBucket("%message{s3-bucket-key}");
         op.setTagMetadataFilter(new NoOpMetadataFilter());
         return op;
       }
@@ -104,7 +103,7 @@ public class S3ServiceTest extends ServiceCase {
       LifecycleHelper.prepare(service);
       LifecycleHelper.init(service);
       fail();
-    } catch (CoreException expected) {
+    } catch (CoreException | IllegalArgumentException expected) {
       
     } finally {
       LifecycleHelper.stopAndClose(service);
@@ -131,7 +130,9 @@ public class S3ServiceTest extends ServiceCase {
     Mockito.doAnswer((i)-> {return null;}).when(connection).stopConnection();
     Mockito.doAnswer((i)-> {return null;}).when(connection).closeConnection();
     Mockito.doAnswer((i)-> {return null;}).when(connection).initConnection();
-    Mockito.doAnswer((i)-> {return null;}).when(operation).execute((ClientWrapper) anyObject(), (AdaptrisMessage) anyObject());
+    Mockito.doAnswer((i) -> {
+      return null;
+    }).when(operation).execute((ClientWrapper) any(), (AdaptrisMessage) any());
     S3Service service = new S3Service(connection, operation);
 
     execute(service, AdaptrisMessageFactory.getDefaultInstance().newMessage());
@@ -147,7 +148,8 @@ public class S3ServiceTest extends ServiceCase {
     Mockito.doAnswer((i)-> {return null;}).when(connection).stopConnection();
     Mockito.doAnswer((i)-> {return null;}).when(connection).closeConnection();
     Mockito.doAnswer((i)-> {return null;}).when(connection).initConnection();
-    Mockito.doThrow(new Exception()).when(operation).execute((ClientWrapper) anyObject(), (AdaptrisMessage) anyObject());
+    Mockito.doThrow(new Exception()).when(operation).execute((ClientWrapper) any(),
+        (AdaptrisMessage) any());
     S3Service service = new S3Service(connection, operation);
 
     try {

--- a/interlok-aws-sns/build.gradle
+++ b/interlok-aws-sns/build.gradle
@@ -61,6 +61,8 @@ publishing {
             properties.appendNode("target", "3.7.2+")
             properties.appendNode("tags", "aws,sns")
             properties.appendNode("license", "false")
+            properties.appendNode("readme", "https://github.com/adaptris/interlok-aws/raw/develop/README.md")
+            properties.appendNode("repository", "https://github.com/adaptris/interlok-aws")
           }
       }
   }

--- a/interlok-aws-sqs/build.gradle
+++ b/interlok-aws-sqs/build.gradle
@@ -62,6 +62,8 @@ publishing {
             properties.appendNode("target", "3.3.0+")
             properties.appendNode("tags", "aws,sqs")
             properties.appendNode("license", "false")
+            properties.appendNode("readme", "https://github.com/adaptris/interlok-aws/raw/develop/README.md")
+            properties.appendNode("repository", "https://github.com/adaptris/interlok-aws")
           }
       }
   }


### PR DESCRIPTION
## Motivation

Previously, BlobListRenderer took a collection as its input for rendering into a message. Since there is technically no limit to the number of blob entries in remote storage (e.g. in an S3 bucket) you could end up creating a list with a huge number of entries ('00000s) which has a cost in terms of memory, performance and garbage collection.

## Modification

### Upstream/Peer projects

- BlobListRenderer in interlok-common had its interface changed to Iterable<RemoteBlob> : https://github.com/adaptris/interlok/commit/6011b7494144cf36dd9c9b73a73aba888e875bb1
- A new class RemoteBlobIterableImpl was added to interlok-common to assist with iterating over remote blobs : https://github.com/adaptris/interlok/commit/6504fd9abfa7bee1e5554dfc00f28dd37b027b79
- JsonBlobRenderer was changed to fit the new interface : https://github.com/adaptris/interlok-json/commit/9499e0b9fe8eedbbb20f5ed51109ac0e10d87c7a
- CSVBlobRenderer was changed to fit the new interface : https://github.com/adaptris/interlok-csv/commit/2ad459ab104a38c4c6dee41a8a9368581fd81d8c

### interlok-aws

- A new class RemoteBlobIterable was that extends RemoteBlobIterableImpl and iterates over the underlying S3ObjectSummary list returned by the V2 Requests.
  - It handles pagination silently; so as a result `pageResults` is now deprecated (and ignored)
- ListOperation switched to using the Iterable implementation rather than reading all the remote blobs into a big old list.
- S3Operation now implements `ComponentLifecycleExtension` since we need to log warnings.
- All the existing "DataInputParameter" fields on S3Operation have been deprecated and superseded by String/expression equivalents.

## Result

- a new `ObjectOperationImpl` class where we are operating on a single S3 Object which classes of that type extend (upload/download/get/tag/delete/copy).
- `bucketName` is deprecated in favour of a `bucket` string parameter, a warning is logged; 
- `key` this is deprecated in favour of a `object-name` string parameter in _ObjectOperationImpl_
- `key` is deprecated in favour of `prefix` in ListOperation
- `ListOperation#pageResults` - this is deprecated, ignored, and a warning is logged.
- `S3BucketList#pageResults` - this is deprecated, ignored, and a warning is logged.
- `S3BucketList#key` is deprecated, in favour of `prefix` for consistency.


Mostly transparent to the end-user. Since there were no behavioural to existing tests, it suggests that there are no regressions.

```
WARN  [JMX-Request-0] [c.a.c.u.LoggingHelper] [ListOperation] uses [bucket-name], use [bucket] instead
WARN  [JMX-Request-0] [c.a.c.u.LoggingHelper] [ListOperation] uses [key], use the alternative string-based expression instead
```

## Testing

You can test both S3 + jclouds in tandem (https://github.com/adaptris/interlok-jclouds/pull/65) since jclouds supports S3.
If your blob storage is backblaze, then this also has a S3 compatibility layer (which means you could do the same thing using jclouds -> b2 and aws -> b2).

You will need `org.apache.jclouds.provider:aws-s3:2.2.1` as an additional dependency for s3; or `org.apache.jclouds.provider:b2:2.2.1` if backblaze is your thing (note that B2 will require custom-endpoints for the S3 connection).

```
<jclouds-blobstore-service>
  <jclouds-blobstore-connection>
    <provider>aws-s3</provider>
    <identity>${s3.access.key}</identity>
    <credentials>${s3.secret.key}</credentials>
  </jclouds-blobstore-connection>
  <operation class="jclouds-blobstore-list">
    <container-name>${s3.bucket}</container-name>
    <output-style class="remote-blob-list-as-json"/>
  </operation>
</jclouds-blobstore-service>
```

```
<amazon-s3-service>
  <amazon-s3-connection>
    <region>${s3.signing.region}</region>
    <credentials class="aws-static-credentials-builder">
      <authentication class="aws-keys-authentication">
        <access-key>${s3.access.key}</access-key>
        <secret-key>${s3.secret.key}</secret-key>
      </authentication>
    </credentials>
  </amazon-s3-connection>              
  <operation class="amazon-s3-list">
    <bucket>${s3.bucket}</bucket>
    <output-style class="remote-blob-list-as-json"/>
  </operation>
</amazon-s3-service>
```

Should have "equivalent" output (taking into account sorting etc).
