### PR TITLE
INTERLOK-3248 Synchronous Kinesis Stream Producer

### DIFF
--- a/interlok-aws-kinesis/src/main/java/com/adaptris/aws/kinesis/ConnectionFromProperties.java
+++ b/interlok-aws-kinesis/src/main/java/com/adaptris/aws/kinesis/ConnectionFromProperties.java
@@ -18,6 +18,8 @@ package com.adaptris.aws.kinesis;
 
 import java.io.InputStream;
 import java.util.Properties;
+
+import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.NotBlank;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
@@ -51,6 +53,7 @@ import lombok.Setter;
 @AdapterComponent
 @ComponentProfile(summary = "Connection for supporting connectivity to AWS Kinesis", tag = "connections,amazon,aws,kinesis")
 @DisplayOrder(order = {"configLocation"})
+@NoArgsConstructor
 public class ConnectionFromProperties extends ProducerLibraryConnection implements KinesisProducerWrapper {
 
   /**
@@ -65,10 +68,6 @@ public class ConnectionFromProperties extends ProducerLibraryConnection implemen
   @Setter
   @NonNull
   private String configLocation;
-
-
-  public ConnectionFromProperties() {
-  }
 
   @Override
   protected void initConnection() throws CoreException {

--- a/interlok-aws-kinesis/src/main/java/com/adaptris/aws/kinesis/KinesisSynchronousStreamProducer.java
+++ b/interlok-aws-kinesis/src/main/java/com/adaptris/aws/kinesis/KinesisSynchronousStreamProducer.java
@@ -12,6 +12,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.NoArgsConstructor;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
  * Producer to amazon kinesis using the Kinesis Producer Library.
  *
@@ -60,15 +62,16 @@ public class KinesisSynchronousStreamProducer extends KinesisStreamProducer {
       result.getShardId(),
       result.getAttempts().size()
     );
-    int i = 1;
-    for(Attempt attempt : result.getAttempts()){
+    AtomicInteger counter = new AtomicInteger(1);
+    result.getAttempts().forEach((attempt) -> {
+      int i =  counter.incrementAndGet();
       log.trace("Attempt [{}]: delay [{}], duration [{}], error code [{}], error message [{}]",
-        i++,
+        i,
         attempt.getDelay(),
         attempt.getDuration(),
         attempt.getErrorCode(),
         attempt.getErrorMessage());
-    }
+    });
   }
 
   public KinesisSynchronousStreamProducer withStream(String s) {

--- a/interlok-aws-kinesis/src/main/java/com/adaptris/aws/kinesis/KinesisSynchronousStreamProducer.java
+++ b/interlok-aws-kinesis/src/main/java/com/adaptris/aws/kinesis/KinesisSynchronousStreamProducer.java
@@ -1,0 +1,83 @@
+package com.adaptris.aws.kinesis;
+
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.ProduceDestination;
+import com.adaptris.core.ProduceException;
+import com.adaptris.core.util.ExceptionHelper;
+import com.amazonaws.services.kinesis.producer.Attempt;
+import com.amazonaws.services.kinesis.producer.UserRecordFailedException;
+import com.amazonaws.services.kinesis.producer.UserRecordResult;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.NoArgsConstructor;
+
+/**
+ * Producer to amazon kinesis using the Kinesis Producer Library.
+ *
+ * <p>
+ * Different from {@link KinesisStreamProducer} in that it waits for a confirmation of produce to the stream,
+ * rather than offloading to the KPL.
+ * </p>
+ * <p>
+ * This departs from a standard producer in the sense the {@link #getDestination()} can be regarded as optional. The reason
+ * for this is that both {@code stream} and {@code partitionKey} are required elements, but {@link #getDestination()} only provides
+ * a single method (of course we could change it to provide more). So the behaviour here is changed so that
+ * <ul>
+ * <li>if {@link #setStream(String)} is blank, then we use {@link #getDestination()}, otherwise
+ * we use {@link #getStream()}.</li>
+ * <li>{@link #setPartitionKey(String)} should always be populated with a non-blank value, which will be used.</li>
+ * </ul>
+ * </p>
+ *
+ * @config aws-kinesis-synchronous-stream-producer
+ */
+@ComponentProfile(summary = "Produce synchronously to Amazon Kinesis using the Kinesis Producer Library", tag = "amazon,aws,kinesis,producer",
+    recommended = {ProducerLibraryConnection.class})
+@XStreamAlias("aws-kinesis-synchronous-stream-producer")
+@NoArgsConstructor
+public class KinesisSynchronousStreamProducer extends KinesisStreamProducer {
+
+  @Override
+  public void produce(AdaptrisMessage msg, ProduceDestination destination) throws ProduceException {
+    try {
+      ListenableFuture<UserRecordResult> results = addUserRecord(msg, destination);
+      UserRecordResult result = results.get();
+      logUserRecordResult(result);
+    } catch (Exception e) {
+      if(e.getCause() instanceof UserRecordFailedException) {
+        UserRecordFailedException userRecordFailedException = (UserRecordFailedException)e.getCause();
+        logUserRecordResult(userRecordFailedException.getResult());
+      }
+      throw ExceptionHelper.wrapProduceException(e);
+    }
+  }
+
+  private void logUserRecordResult(UserRecordResult result){
+    log.debug("KPL Result: isSuccessful [{}], sequenceNumber [{}], shardId [{}], attempts [{}]",
+      result.isSuccessful(),
+      result.getSequenceNumber(),
+      result.getShardId(),
+      result.getAttempts().size()
+    );
+    int i = 1;
+    for(Attempt attempt : result.getAttempts()){
+      log.trace("Attempt [{}]: delay [{}], duration [{}], error code [{}], error message [{}]",
+        i++,
+        attempt.getDelay(),
+        attempt.getDuration(),
+        attempt.getErrorCode(),
+        attempt.getErrorMessage());
+    }
+  }
+
+  public KinesisSynchronousStreamProducer withStream(String s) {
+    setStream(s);
+    return this;
+  }
+
+  public KinesisSynchronousStreamProducer withPartitionKey(String s) {
+    setPartitionKey(s);
+    return this;
+  }
+}

--- a/interlok-aws-kinesis/src/main/java/com/adaptris/aws/kinesis/ProducerLibraryConnection.java
+++ b/interlok-aws-kinesis/src/main/java/com/adaptris/aws/kinesis/ProducerLibraryConnection.java
@@ -20,17 +20,17 @@ import com.adaptris.core.AdaptrisConnection;
 import com.adaptris.core.AdaptrisConnectionImp;
 import com.adaptris.core.CoreException;
 import com.amazonaws.services.kinesis.producer.KinesisProducer;
+import lombok.NoArgsConstructor;
 
 /**
  * {@linkplain AdaptrisConnection} implementation for Amazon Kinesis using the Kinesis Producer Library.
  * 
  * 
  */
+@NoArgsConstructor
 public abstract class ProducerLibraryConnection extends AdaptrisConnectionImp implements KinesisProducerWrapper {
 
   protected transient KinesisProducer producer = null;
-
-  public ProducerLibraryConnection() {}
 
   @Override
   protected void prepareConnection() throws CoreException {}


### PR DESCRIPTION
## Motivation

Adding a synchronous kinesis stream producer which waits for a response form KPL

## Modification

Added a new producer which extends the existing producer and overrides produce.

## Result

New producer which waits for KPL future to respond.

## Testing

Follow [Testing Interlok interoperability with AWS](https://interlok.adaptris.net/blog/2019/08/30/interlok-interop-with-aws.html), replacing the producer with the following:

```xml
      <producer class="aws-kinesis-synchronous-stream-producer">
        <stream>myStream</stream>
        <partition-key>myPartition</partition-key>
      </producer>
```

Run two tests:

1. With the stream not created (in the other implementation curl would return straight away, it will now wait until exception is reported)
2. With the stream created
