### PR TITLE
INTERLOK-3318 extended S3 copy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,18 +8,18 @@ plugins {
 }
 
 ext {
-  interlokCoreVersion = project.hasProperty('interlokCoreVersion') ? project.getProperty('interlokCoreVersion') : '3.10-SNAPSHOT'
-  releaseVersion = project.hasProperty('releaseVersion') ? project.getProperty('releaseVersion') : '3.10-SNAPSHOT'
-  nexusBaseUrl = project.hasProperty('nexusBaseUrl') ? project.getProperty('nexusBaseUrl') : 'https://nexus.adaptris.net/nexus'
-  mavenPublishUrl = project.hasProperty('mavenPublishUrl') ? project.getProperty('mavenPublishUrl') : nexusBaseUrl + '/content/repositories/snapshots'
+  interlokCoreVersion = project.findProperty('interlokCoreVersion') ?: '3.10-SNAPSHOT'
+  releaseVersion = project.findProperty('releaseVersion') ?: '3.10-SNAPSHOT'
+  nexusBaseUrl = project.findProperty('nexusBaseUrl') ?: 'https://nexus.adaptris.net/nexus'
+  mavenPublishUrl = project.findProperty('mavenPublishUrl') ?: nexusBaseUrl + '/content/repositories/snapshots'
   javadocsBaseUrl = nexusBaseUrl + "/content/sites/javadocs/com/adaptris"
-  repoUsername = project.hasProperty('repoUsername') ? project.getProperty('repoUsername') : 'unknown'
-  repoPassword = project.hasProperty('repoPassword') ? project.getProperty('repoPassword') : 'unknown'
-  defaultNexusRepo = project.hasProperty('defaultNexusRepo') ? project.getProperty('defaultNexusRepo') : 'https://repo1.maven.org/maven2/'
+  repoUsername = project.findProperty('repoUsername') ?: 'please set as gradle property'
+  repoPassword = project.findProperty('repoPassword') ?: 'please set as gradle property'
+  defaultNexusRepo = project.findProperty('defaultNexusRepo') ?: 'https://repo1.maven.org/maven2/'
   offlineJavadocPackageDir = new File(project.buildDir, "offline-javadoc-packages")
 
-  interlokJavadocs= project.hasProperty('interlokJavadocs') ? project.getProperty('interlokJavadocs') : javadocsBaseUrl + "/interlok-core/" + interlokCoreVersion
-  interlokCommonJavadocs= project.hasProperty('interlokJavadocs') ? project.getProperty('interlokJavadocs') : javadocsBaseUrl + "/interlok-common/" + interlokCoreVersion
+  interlokJavadocs= project.findProperty('interlokJavadocs') ?: javadocsBaseUrl + "/interlok-core/" + interlokCoreVersion
+  interlokCommonJavadocs= project.findProperty('interlokJavadocs') ?: javadocsBaseUrl + "/interlok-common/" + interlokCoreVersion
   organizationName = "Adaptris Ltd"
 
   slf4jVersion = '1.7.30'

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/CopyOperation.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/CopyOperation.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2018 Adaptris
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -26,6 +26,7 @@ import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.interlok.InterlokException;
 import com.adaptris.interlok.config.DataInputParameter;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CopyObjectRequest;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -33,12 +34,14 @@ import lombok.Setter;
 
 /**
  * Copy an object from S3 to another object
- * 
+ *
  * <p>
- * Uses {@link AmazonS3Client#copyObject(String, String, String, String)} using only the default
- * behaviour.
+ * Effectively uses {@link AmazonS3Client#copyObject(String, String, String, String)} using only the
+ * default behaviour. Note that by default the {@code server-side-encryption, storage-class} and
+ * {@code website-redirect-location} are not copied to the destination object. If you need those
+ * settings then you should probably think about using {@link ExtendedCopyOperation} instead.
  * </p>
- * 
+ *
  * @config amazon-s3-copy
  */
 @AdapterComponent
@@ -47,7 +50,7 @@ import lombok.Setter;
 @DisplayOrder(order = {"bucket", "objectName", "destinationBucket", "destinationObjectName",
     "bucketName", "key", "destinationBucketName", "destinationKey"})
 @NoArgsConstructor
-public class CopyOperation extends ObjectOperationImpl {
+public class CopyOperation extends CopyOperationImpl {
   private transient boolean bucketNameWarningLogged = false;
   private transient boolean keyNameWarningLogged = false;
 
@@ -69,29 +72,10 @@ public class CopyOperation extends ObjectOperationImpl {
    */
   @Valid
   @Getter
-  @Setter  
+  @Setter
   @Deprecated
   @Removal(version = "3.12.0", message = "Use an expression based key instead")
   private DataInputParameter<String> destinationKey;
-  
-  /**
-   * The destination bucket.
-   * <p>
-   * If not explictly configured, then we use the bucket name instead making the assumption it's a
-   * copy within the same bucket.
-   * </p>
-   */
-  @Getter
-  @Setter
-  private String destinationBucket;
-  
-  /**
-   * The destination object.
-   */
-  @Getter
-  @Setter
-  // @NotBlank because of deprecated thing.
-  private String destinationObjectName;
 
 
   @Override
@@ -111,14 +95,11 @@ public class CopyOperation extends ObjectOperationImpl {
   }
 
   @Override
-  public void execute(ClientWrapper wrapper, AdaptrisMessage msg) throws Exception {
-    AmazonS3Client s3 = wrapper.amazonClient();
-    String srcBucket = s3Bucket(msg);
-    String srcKey = s3ObjectKey(msg);
-    String destBucket = destinationBucket(msg);
-    String destKey = destinationKey(msg);
-    log.trace("Copying [{}:{}] to [{}:{}]", srcBucket, srcKey, destBucket, destKey);
-    s3.copyObject(srcBucket, srcKey, destBucket, destKey);
+  protected CopyObjectRequest createCopyRequest(ClientWrapper wrapper, AdaptrisMessage msg)
+      throws Exception {
+    CopyObjectRequest copyReq = new CopyObjectRequest(s3Bucket(msg), s3ObjectKey(msg),
+        destinationBucket(msg), destinationKey(msg));
+    return copyReq;
   }
 
   @Deprecated
@@ -133,17 +114,6 @@ public class CopyOperation extends ObjectOperationImpl {
     setDestinationKey(key);
     return this;
   }
-
-  public CopyOperation withDestinationBucket(String s) {
-    setDestinationBucket(s);
-    return this;
-  }
-
-  public CopyOperation withDestinationObjectName(String s) {
-    setDestinationObjectName(s);
-    return this;
-  }
-
 
   private String destinationKey(AdaptrisMessage msg) throws InterlokException {
     return resolve(getDestinationKey(), getDestinationObjectName(), msg);

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/CopyOperationImpl.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/CopyOperationImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 Adaptris
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.adaptris.aws.s3;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CopyObjectRequest;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Copy an object from S3 to another object
+ *
+ */
+@NoArgsConstructor
+public abstract class CopyOperationImpl extends ObjectOperationImpl {
+
+  /**
+   * The destination bucket.
+   * <p>
+   * If not explictly configured, then we use the bucket name instead making the assumption it's a
+   * copy within the same bucket.
+   * </p>
+   */
+  @Getter
+  @Setter
+  private String destinationBucket;
+
+  /**
+   * The destination object.
+   */
+  @Getter
+  @Setter
+  // @NotBlank because of deprecated thing.
+  private String destinationObjectName;
+
+
+
+  @Override
+  public void execute(ClientWrapper wrapper, AdaptrisMessage msg) throws Exception {
+    AmazonS3Client s3 = wrapper.amazonClient();
+    CopyObjectRequest copyReq = createCopyRequest(wrapper, msg);
+    log.trace("Copying [{}:{}] to [{}:{}]", copyReq.getSourceBucketName(), copyReq.getSourceKey(),
+        copyReq.getDestinationBucketName(), copyReq.getDestinationKey());
+    s3.copyObject(copyReq);
+  }
+
+  protected abstract CopyObjectRequest createCopyRequest(ClientWrapper wrapper, AdaptrisMessage msg)
+      throws Exception;
+
+  @SuppressWarnings("unchecked")
+  public <T extends CopyOperationImpl> T withDestinationBucket(String s) {
+    setDestinationBucket(s);
+    return (T) this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public <T extends CopyOperationImpl> T withDestinationObjectName(String s) {
+    setDestinationObjectName(s);
+    return (T) this;
+  }
+}

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/ExtendedCopyOperation.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/ExtendedCopyOperation.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020 Adaptris
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.adaptris.aws.s3;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.validation.Valid;
+import org.apache.commons.lang3.ObjectUtils;
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.aws.s3.meta.S3ObjectMetadata;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.CoreException;
+import com.adaptris.interlok.util.Args;
+import com.adaptris.util.KeyValuePair;
+import com.adaptris.util.KeyValuePairSet;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CopyObjectRequest;
+import com.amazonaws.services.s3.model.GetObjectTaggingRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.ObjectTagging;
+import com.amazonaws.services.s3.model.Tag;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Copy an object from S3 to another object
+ *
+ * <p>
+ * By default this operation gets the existing ObjectMetadata and Tags associated with the S3
+ * object, and ensures that they are applied to the underlying {@code CopyObjectRequest}. You also
+ * have the option to force various settings using the {@code object-metadata} and
+ * {@code object-tags} members as required. If you're using the Amazon S3 API against a different
+ * provider then your mileage may vary since {@code object-tags} and {@code object-metadata} might
+ * not translate to alternate providers.
+ * </p>
+ *
+ * @config amazon-s3-extended-copy
+ */
+@AdapterComponent
+@ComponentProfile(summary = "Copy an object in S3 to another Object", since = "3.10.2")
+@XStreamAlias("amazon-s3-extended-copy")
+@DisplayOrder(order = {"bucket", "objectName", "destinationBucket", "destinationObjectName"})
+@NoArgsConstructor
+public class ExtendedCopyOperation extends CopyOperationImpl {
+
+  /**
+   * Any specific object metadata that you want to force on the destination object.
+   */
+  @Setter
+  @Getter
+  @AdvancedConfig
+  @Valid
+  private List<S3ObjectMetadata> objectMetadata;
+
+  /**
+   * Any specific object tags that you want to force on the destination object.
+   */
+  @Setter
+  @Getter
+  @AdvancedConfig
+  @Valid
+  private KeyValuePairSet objectTags;
+
+  @Override
+  public void prepare() throws CoreException {
+    super.prepare();
+    Args.notBlank(getDestinationObjectName(), "destination-object-name");
+  }
+
+  @Override
+  protected CopyObjectRequest createCopyRequest(ClientWrapper wrapper, AdaptrisMessage msg)
+      throws Exception {
+    AmazonS3Client s3 = wrapper.amazonClient();
+    String srcBucket = s3Bucket(msg);
+    String srcKey = s3ObjectKey(msg);
+    String destBucket = ObjectUtils.defaultIfNull(msg.resolve(getDestinationBucket()), srcBucket);
+    String destKey = msg.resolve(getDestinationObjectName());
+    CopyObjectRequest copyReq = new CopyObjectRequest(srcBucket, srcKey, destBucket, destKey)
+        .withNewObjectMetadata(buildNewMetadata(s3, msg, srcBucket, srcKey))
+        .withNewObjectTagging(new ObjectTagging(buildNewTags(s3, srcBucket, srcKey)));
+    return copyReq;
+  }
+
+  private List<Tag> buildNewTags(AmazonS3Client s3, String srcBucket, String srcKey) {
+    GetObjectTaggingRequest req = new GetObjectTaggingRequest(srcBucket, srcKey);
+    List<Tag> result = new ArrayList<>(s3.getObjectTagging(req).getTagSet());
+    for (KeyValuePair k : overrideTags()) {
+      result.add(new Tag(k.getKey(), k.getValue()));
+    }
+    return result;
+  }
+
+  private ObjectMetadata buildNewMetadata(AmazonS3Client s3, AdaptrisMessage msg,
+      String srcBucket,
+      String srcKey) throws Exception {
+    ObjectMetadata result = s3.getObjectMetadata(srcBucket, srcKey).clone();
+    for (S3ObjectMetadata m : overrideMetadata()) {
+      m.apply(msg, result);
+    }
+    return result;
+  }
+
+  public ExtendedCopyOperation withObjectMetadata(List<S3ObjectMetadata> meta) {
+    setObjectMetadata(meta);
+    return this;
+  }
+
+  public ExtendedCopyOperation withObjectTags(KeyValuePairSet tags) {
+    setObjectTags(tags);
+    return this;
+  }
+
+  private List<S3ObjectMetadata> overrideMetadata() {
+    return ObjectUtils.defaultIfNull(getObjectMetadata(), Collections.EMPTY_LIST);
+  }
+
+  private KeyValuePairSet overrideTags() {
+    return ObjectUtils.defaultIfNull(getObjectTags(), new KeyValuePairSet());
+  }
+}

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/ExtendedCopyOperation.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/ExtendedCopyOperation.java
@@ -15,6 +15,7 @@
 package com.adaptris.aws.s3;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import javax.validation.Valid;
@@ -123,10 +124,19 @@ public class ExtendedCopyOperation extends CopyOperationImpl {
     return this;
   }
 
+  public ExtendedCopyOperation withObjectMetadata(S3ObjectMetadata... meta) {
+    return withObjectMetadata(new ArrayList(Arrays.asList(meta)));
+  }
+
   public ExtendedCopyOperation withObjectTags(KeyValuePairSet tags) {
     setObjectTags(tags);
     return this;
   }
+
+  public ExtendedCopyOperation withObjectTags(KeyValuePair... tags) {
+    return withObjectTags(new KeyValuePairSet(Arrays.asList(tags)));
+  }
+
 
   private List<S3ObjectMetadata> overrideMetadata() {
     return ObjectUtils.defaultIfNull(getObjectMetadata(), Collections.EMPTY_LIST);

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ContentDisposition.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ContentDisposition.java
@@ -23,33 +23,32 @@ import com.adaptris.core.ServiceException;
 import com.adaptris.interlok.util.Args;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
 
 @XStreamAlias("s3-content-disposition")
 // @XStreamConverter(value = ToAttributedValueConverter.class, strings = { "contentDisposition" })
+@NoArgsConstructor
 public class S3ContentDisposition extends S3ObjectMetadata {
 
+  /**
+   * Sets the optional Content-Disposition HTTP header, which specifies presentational information
+   * such as the recommended filename for the object to be saved as.
+   *
+   */
   @NotNull
   @InputFieldHint(expression = true)
+  @Getter
+  @Setter
+  @NonNull
   private String contentDisposition;
 
   @Override
   public void apply(AdaptrisMessage msg, ObjectMetadata meta) throws ServiceException {
     Args.notNull(getContentDisposition(), "content-disposition");
     meta.setContentDisposition(msg.resolve(getContentDisposition()));
-  }
-
-  public String getContentDisposition() {
-    return contentDisposition;
-  }
-
-  /**
-   * Sets the optional Content-Disposition HTTP header, which specifies 
-   * presentational information such as the recommended filename for the object to be saved as.
-   * 
-   * @param contentDisposition
-   */
-  public void setContentDisposition(String contentDisposition) {
-    this.contentDisposition = contentDisposition;
   }
 
 }

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ContentEncoding.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ContentEncoding.java
@@ -23,13 +23,27 @@ import com.adaptris.core.ServiceException;
 import com.adaptris.interlok.util.Args;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
 
 @XStreamAlias("s3-content-encoding")
 // @XStreamConverter(value = ToAttributedValueConverter.class, strings = { "contentEncoding" })
+@NoArgsConstructor
 public class S3ContentEncoding extends S3ObjectMetadata {
 
+  /**
+   * Sets the optional Content-Encoding HTTP header specifying what content encodings have been
+   * applied to the object and what decoding mechanisms must be applied in order to obtain the
+   * media-type referenced by the Content-Type field.
+   *
+   */
   @NotNull
   @InputFieldHint(expression = true)
+  @Getter
+  @Setter
+  @NonNull
   private String contentEncoding;
 
   @Override
@@ -37,21 +51,4 @@ public class S3ContentEncoding extends S3ObjectMetadata {
     Args.notNull(getContentEncoding(), "content-encoding");
     meta.setContentEncoding(msg.resolve(getContentEncoding()));
   }
-
-  public String getContentEncoding() {
-    return contentEncoding;
-  }
-
-  /**
-   * Sets the optional Content-Encoding HTTP header specifying what
-   * content encodings have been applied to the object and what decoding
-   * mechanisms must be applied in order to obtain the media-type referenced
-   * by the Content-Type field.
-   *
-   * @param contentEncoding
-   */
-  public void setContentEncoding(String contentEncoding) {
-    this.contentEncoding = contentEncoding;
-  }
-
 }

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ContentLanguage.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ContentLanguage.java
@@ -23,33 +23,32 @@ import com.adaptris.core.ServiceException;
 import com.adaptris.interlok.util.Args;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
 
 @XStreamAlias("s3-content-language")
 // @XStreamConverter(value = ToAttributedValueConverter.class, strings = { "contentLanguage" })
+@NoArgsConstructor
 public class S3ContentLanguage extends S3ObjectMetadata {
 
+  /**
+   * Sets the Content-Language HTTP header which describes the natural language(s) of the intended
+   * audience for the enclosed entity.
+   *
+   * @param contentLanguage
+   */
   @NotNull
+  @Getter
+  @Setter
+  @NonNull
   @InputFieldHint(expression = true)
   private String contentLanguage;
-  
+
   @Override
   public void apply(AdaptrisMessage msg, ObjectMetadata meta) throws ServiceException {
     Args.notNull(getContentLanguage(), "content-language");
     meta.setContentLanguage(msg.resolve(getContentLanguage()));
   }
-
-  public String getContentLanguage() {
-    return contentLanguage;
-  }
-
-  /**
-   * Sets the Content-Language HTTP header which describes the natural 
-   * language(s) of the intended audience for the enclosed entity.
-   * 
-   * @param contentLanguage
-   */
-  public void setContentLanguage(String contentLanguage) {
-    this.contentLanguage = contentLanguage;
-  }
-
 }

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ContentType.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ContentType.java
@@ -23,38 +23,38 @@ import com.adaptris.core.ServiceException;
 import com.adaptris.interlok.util.Args;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
 
 @XStreamAlias("s3-content-type")
 // @XStreamConverter(value = ToAttributedValueConverter.class, strings = { "contentType" })
+@NoArgsConstructor
 public class S3ContentType extends S3ObjectMetadata {
 
+  /**
+   * Sets the Content-Type HTTP header indicating the type of content stored in the associated
+   * object.
+   * <p>
+   * The value of this header is a standard MIME type. When uploading files, the AWS S3 Java client
+   * will attempt to determine the correct content type if one hasn't been set yet. Users are
+   * responsible for ensuring a suitable content type is set when uploading streams. If no content
+   * type is provided and cannot be determined by the filename, the default content type
+   * "application/octet-stream" will be used.
+   * </p>
+   */
   @NotNull
   @InputFieldHint(expression = true)
+  @Getter
+  @Setter
+  @NonNull
   private String contentType;
 
   @Override
   public void apply(AdaptrisMessage msg, ObjectMetadata meta) throws ServiceException {
     Args.notNull(getContentType(), "content-type");
     meta.setContentType(msg.resolve(getContentType()));
-  }
-
-  public String getContentType() {
-    return contentType;
-  }
-
-  /**
-   * Sets the Content-Type HTTP header indicating the type of content stored in the associated object. 
-   * The value of this header is a standard MIME type.
-   * <br/>
-   * When uploading files, the AWS S3 Java client will attempt to determine the correct content type if 
-   * one hasn't been set yet. Users are responsible for ensuring a suitable content type is set when 
-   * uploading streams. If no content type is provided and cannot be determined by the filename, the default 
-   * content type "application/octet-stream" will be used.
-   * 
-   * @param contentType
-   */
-  public void setContentType(String contentType) {
-    this.contentType = contentType;
   }
 
 }

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ExpirationTimeRuleId.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ExpirationTimeRuleId.java
@@ -18,35 +18,61 @@ package com.adaptris.aws.s3.meta;
 
 import javax.validation.constraints.NotNull;
 import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ServiceException;
+import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.interlok.util.Args;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
 
 @XStreamAlias("s3-expiration-rule-id")
 // @XStreamConverter(value = ToAttributedValueConverter.class, strings = { "expirationRuleId" })
+@NoArgsConstructor
 public class S3ExpirationTimeRuleId extends S3ObjectMetadata {
 
-  @NotNull
-  @InputFieldHint(expression = true)
-  private String expirationRuleId;
-  
-  @Override
-  public void apply(AdaptrisMessage msg, ObjectMetadata meta) throws ServiceException {
-    Args.notNull(getExpirationTimeRuleId(), "expiration-rule-id");
-    meta.setExpirationTimeRuleId(msg.resolve(getExpirationTimeRuleId()));
-  }
+  private transient boolean warningLogged = false;
 
-  public String getExpirationTimeRuleId() {
-    return expirationRuleId;
-  }
+  /**
+   * Sets the BucketLifecycleConfiguration rule ID for this object's expiration.
+   *
+   * @deprecated since 3.10.2 naming mismatch, use {@link #setExpirationTimeRuleId(String)} instead.
+   *
+   */
+  @InputFieldHint(expression = true)
+  @Getter
+  @Setter
+  @Deprecated
+  @Removal(version = "3.12.0", message = "naming mismatch, use 'expiration-time-rule-id' instead")
+  private String expirationRuleId;
 
   /**
    * Sets the BucketLifecycleConfiguration rule ID for this object's expiration.
    */
-  public void setExpirationTimeRuleId(String expirationRuleId) {
-    this.expirationRuleId = expirationRuleId;
+  @NotNull
+  @InputFieldHint(expression = true)
+  @Getter
+  @Setter
+  @NonNull
+  private String expirationTimeRuleId;
+
+  @Override
+  public void apply(AdaptrisMessage msg, ObjectMetadata meta) throws ServiceException {
+    String ruleId = Args.notNull(ruleIdSelector(), "expiration rule");
+    meta.setExpirationTimeRuleId(msg.resolve(ruleId));
+  }
+
+  private String ruleIdSelector() {
+    if (getExpirationRuleId() != null) {
+      LoggingHelper.logDeprecation(warningLogged, () -> warningLogged = true, "expiration-rule-id",
+          "expiration-time-rule-id");
+      return getExpirationRuleId();
+    }
+    return getExpirationTimeRuleId();
   }
 
 }

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3HttpExpiresDate.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3HttpExpiresDate.java
@@ -25,32 +25,32 @@ import com.adaptris.interlok.util.Args;
 import com.adaptris.util.TimeInterval;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
 
 @XStreamAlias("s3-http-expires-date")
+@NoArgsConstructor
 public class S3HttpExpiresDate extends S3ObjectMetadata {
 
+  /**
+   * Set how long after upload the object should remain cachable
+   *
+   */
   @NotNull
   @Valid
+  @Getter
+  @Setter
+  @NonNull
   private TimeInterval timeToLive;
-  
+
   @Override
   public void apply(AdaptrisMessage msg, ObjectMetadata meta) throws ServiceException {
     Args.notNull(getTimeToLive(), "time-to-live");
     Calendar cal = Calendar.getInstance();
     cal.add(Calendar.MILLISECOND, (int)getTimeToLive().toMilliseconds());
     meta.setHttpExpiresDate(cal.getTime());
-  }
-
-  public TimeInterval getTimeToLive() {
-    return timeToLive;
-  }
-
-  /**
-   * Set how long after upload the object should remain cachable
-   * @param timeToLive
-   */
-  public void setTimeToLive(TimeInterval timeToLive) {
-    this.timeToLive = timeToLive;
   }
 
 }

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ServerSideEncryption.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ServerSideEncryption.java
@@ -25,6 +25,7 @@ import com.adaptris.core.AdaptrisMessage;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.Setter;
 
 /**
@@ -37,27 +38,43 @@ public class S3ServerSideEncryption extends S3ObjectMetadata {
     AES_256(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION);
 
     private final String name;
-    
+
     private Algorithm(String name) {
       this.name = name;
     }
-    
+
     public void apply(ObjectMetadata meta) {
       meta.setSSEAlgorithm(name);
     }
   }
 
-  @AdvancedConfig
+  /**
+   * Whether or not to actually enable server side encryption.
+   *
+   * <p>
+   * This is arguably meaningless since why would you want to define s3-serverside-encryption if you
+   * didn't want it, however, it can be useful as a variable substitution flag where some
+   * environments might not need it.
+   * </p>
+   */
+  @AdvancedConfig(rare = true)
   @InputFieldDefault(value = "true")
   @Getter
   @Setter
   private Boolean enabled;
-  
+
+  /**
+   * Set the algorithm for server side encryption
+   *
+   */
   @NotNull
   @AutoPopulated
   @AdvancedConfig
+  @Getter
+  @Setter
+  @NonNull
   private Algorithm algorithm;
-  
+
   public S3ServerSideEncryption() {
     setAlgorithm(Algorithm.AES_256);
   }
@@ -67,19 +84,6 @@ public class S3ServerSideEncryption extends S3ObjectMetadata {
     if (enabled()) {
       getAlgorithm().apply(meta);
     }
-  }
-
-  public Algorithm getAlgorithm() {
-    return algorithm;
-  }
-
-  /**
-   * Set the algorithm for server side encryption
-   * 
-   * @param algorithm
-   */
-  public void setAlgorithm(Algorithm algorithm) {
-    this.algorithm = algorithm;
   }
 
   private boolean enabled() {

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/MockedOperationTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/MockedOperationTest.java
@@ -18,7 +18,6 @@ import java.util.Map;
 import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.junit.Test;
 import org.mockito.Mockito;
-import com.adaptris.aws.s3.meta.S3ObjectMetadata;
 import com.adaptris.aws.s3.meta.S3ServerSideEncryption;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -27,7 +26,6 @@ import com.adaptris.core.lms.FileBackedMessageFactory;
 import com.adaptris.core.metadata.NoOpMetadataFilter;
 import com.adaptris.interlok.cloud.RemoteBlobFilterWrapper;
 import com.adaptris.util.KeyValuePair;
-import com.adaptris.util.KeyValuePairSet;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CopyObjectResult;
 import com.amazonaws.services.s3.model.GetObjectRequest;
@@ -128,11 +126,10 @@ public class MockedOperationTest {
     Mockito.when(client.copyObject(any())).thenReturn(result);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
 
-    KeyValuePairSet tags =
-        new KeyValuePairSet(Arrays.asList(new KeyValuePair("goodbye", "cruel world")));
-    List<S3ObjectMetadata> newMetadata = new ArrayList(Arrays.asList(new S3ServerSideEncryption()));
-    ExtendedCopyOperation op = new ExtendedCopyOperation().withObjectMetadata(newMetadata)
-        .withObjectTags(tags).withDestinationBucket("destBucket")
+    ExtendedCopyOperation op =
+        new ExtendedCopyOperation().withObjectMetadata(new S3ServerSideEncryption())
+            .withObjectTags(new KeyValuePair("goodbye", "cruel world"))
+            .withDestinationBucket("destBucket")
         .withDestinationObjectName("destKey").withObjectName("key").withBucket("bucketName");
     ClientWrapper wrapper = new ClientWrapperImpl(client);
     execute(op, wrapper, msg);

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/S3ObjectMetadataTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/S3ObjectMetadataTest.java
@@ -1,0 +1,107 @@
+package com.adaptris.aws.s3;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import com.adaptris.aws.s3.meta.S3ContentDisposition;
+import com.adaptris.aws.s3.meta.S3ContentEncoding;
+import com.adaptris.aws.s3.meta.S3ContentLanguage;
+import com.adaptris.aws.s3.meta.S3ContentType;
+import com.adaptris.aws.s3.meta.S3ExpirationTimeRuleId;
+import com.adaptris.aws.s3.meta.S3HttpExpiresDate;
+import com.adaptris.aws.s3.meta.S3ServerSideEncryption;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.util.TimeInterval;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+
+public class S3ObjectMetadataTest {
+
+  @Test
+  public void testContentDisposition() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    S3ContentDisposition om = new S3ContentDisposition();
+    om.setContentDisposition("content disposition");
+    ObjectMetadata meta = new ObjectMetadata();
+    om.apply(msg, meta);
+    assertEquals("content disposition", meta.getContentDisposition());
+  }
+
+
+  @Test
+  public void testContentLanguage() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    S3ContentLanguage om = new S3ContentLanguage();
+    om.setContentLanguage("content language");
+    ObjectMetadata meta = new ObjectMetadata();
+    om.apply(msg, meta);
+    assertEquals("content language", meta.getContentLanguage());
+  }
+
+  @Test
+  public void testContentType() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    S3ContentType om = new S3ContentType();
+    om.setContentType("content type");
+    ObjectMetadata meta = new ObjectMetadata();
+    om.apply(msg, meta);
+    assertEquals("content type", meta.getContentType());
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testExpirationRuleId() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    S3ExpirationTimeRuleId om = new S3ExpirationTimeRuleId();
+    om.setExpirationRuleId("deprecated expiration rule");
+    ObjectMetadata meta = new ObjectMetadata();
+    om.apply(msg, meta);
+    assertEquals("deprecated expiration rule", meta.getExpirationTimeRuleId());
+    om.setExpirationRuleId(null);
+    om.setExpirationTimeRuleId("proper rule id");
+    om.apply(msg, meta);
+    assertEquals("proper rule id", meta.getExpirationTimeRuleId());
+  }
+
+  @Test
+  public void testExpiresDate() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    S3HttpExpiresDate om = new S3HttpExpiresDate();
+    om.setTimeToLive(new TimeInterval(10L, TimeUnit.SECONDS));
+    ObjectMetadata meta = new ObjectMetadata();
+    om.apply(msg, meta);
+    Date expirationDate = meta.getHttpExpiresDate();
+    assertTrue("Expiration date too small",
+        expirationDate.getTime() > (new Date().getTime() + 9000));
+    assertTrue("Expiration date too large",
+        expirationDate.getTime() < (new Date().getTime() + 11000));
+  }
+
+
+  @Test
+  public void testContentEncoding() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    S3ContentEncoding om = new S3ContentEncoding();
+    om.setContentEncoding("content encoding");
+    ObjectMetadata meta = new ObjectMetadata();
+    om.apply(msg, meta);
+    assertEquals("content encoding", meta.getContentEncoding());
+  }
+
+  @Test
+  public void testServersideEncryption() throws Exception {
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    S3ServerSideEncryption om = new S3ServerSideEncryption();
+    ObjectMetadata meta = new ObjectMetadata();
+    om.apply(msg, meta);
+    assertEquals(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION, meta.getSSEAlgorithm());
+    om.setEnabled(false);
+    meta = new ObjectMetadata();
+    om.apply(msg, meta);
+    assertNull(meta.getSSEAlgorithm());
+  }
+
+}

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/S3ServiceTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/S3ServiceTest.java
@@ -18,6 +18,7 @@ package com.adaptris.aws.s3;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -51,7 +52,7 @@ public class S3ServiceTest extends ServiceCase {
         op.setTempDirectory("/path/to/temp/dir/if/required");
         return op;
       }
-      
+
     },
     Get {
       @Override
@@ -74,6 +75,26 @@ public class S3ServiceTest extends ServiceCase {
         type.setContentLanguage("english");
         op.withObjectMetadata(new S3ServerSideEncryption(), type);
         return op;
+      }
+    },
+    Copy {
+      @Override
+      S3Operation build() {
+        return new CopyOperation()
+            .withDestinationObjectName("%message{s3-dest-key}")
+            .withObjectName("%message{s3-src-key}")
+            .withBucket("MyS3Bucket");
+      }
+    },
+    ExtendedCopy {
+      @Override
+      S3Operation build() {
+        S3ContentLanguage lang = new S3ContentLanguage();
+        lang.setContentLanguage("english");
+        return new ExtendedCopyOperation()
+            .withObjectMetadata(new ArrayList<>(Arrays.asList(new S3ServerSideEncryption(), lang)))
+            .withDestinationObjectName("%message{s3-dest-key}")
+            .withObjectName("%message{s3-src-key}").withBucket("MyS3Bucket");
       }
     },
     Tag {
@@ -104,7 +125,7 @@ public class S3ServiceTest extends ServiceCase {
       LifecycleHelper.init(service);
       fail();
     } catch (CoreException | IllegalArgumentException expected) {
-      
+
     } finally {
       LifecycleHelper.stopAndClose(service);
     }
@@ -119,12 +140,12 @@ public class S3ServiceTest extends ServiceCase {
     LifecycleHelper.initAndStart(service);
     LifecycleHelper.stopAndClose(service);
   }
-  
+
   @Test
   public void testDoService() throws Exception {
     AmazonS3Connection connection = Mockito.mock(AmazonS3Connection.class);
     S3Operation operation = Mockito.mock(S3Operation.class);
-    
+
     Mockito.doAnswer((i)-> {return null;}).when(connection).prepareConnection();
     Mockito.doAnswer((i)-> {return null;}).when(connection).startConnection();
     Mockito.doAnswer((i)-> {return null;}).when(connection).stopConnection();
@@ -137,12 +158,12 @@ public class S3ServiceTest extends ServiceCase {
 
     execute(service, AdaptrisMessageFactory.getDefaultInstance().newMessage());
   }
-  
+
   @Test
   public void testDoService_Exception() throws Exception {
     AmazonS3Connection connection = Mockito.mock(AmazonS3Connection.class);
     S3Operation operation = Mockito.mock(S3Operation.class);
-    
+
     Mockito.doAnswer((i)-> {return null;}).when(connection).prepareConnection();
     Mockito.doAnswer((i)-> {return null;}).when(connection).startConnection();
     Mockito.doAnswer((i)-> {return null;}).when(connection).stopConnection();
@@ -156,11 +177,11 @@ public class S3ServiceTest extends ServiceCase {
       execute(service, AdaptrisMessageFactory.getDefaultInstance().newMessage());
       fail();
     } catch (ServiceException expected) {
-      
+
     }
-    
+
   }
-  
+
   @Override
   protected S3Service retrieveObjectForSampleConfig() {
     return null;


### PR DESCRIPTION
## Motivation

By default the S3 copy operation preserves object metadata apart from `storage-class`, `server-side-encryption` and `website-redirect-location` unless you modify the underlying _CopyObjectRequest_ (which `CopyOperation` does not).

Also, during the copy phase, you may be copying into a bucket that requires you to use `server-side-encryption` which means that the copy might fail.


## Modification

Added a new `amazon-s3-extended-copy` operation which follows the existing configuration pattern for _CopyOperation_ but exposes additional object tags and object metadata.
Additionallyh

## Result

No change for the user of the existing CopyOperations.
There is now a new extended-copy-operation available in the drop down.

## Testing

Check the examples `build/examples/services/com.adaptris.aws.s3.S3Service-ExtendedCopyOperation.xml` but this should work.

```
  <amazon-s3-service>
   <connection class="amazon-s3-connection">
    <credentials class="aws-static-credentials-builder">
     <authentication class="aws-default-authentication"/>
    </credentials>
   </connection>
   <operation class="amazon-s3-extended-copy">
    <bucket>%message{s3-bucket-key}</bucket>
    <object-name>%message{s3-src-key}</object-name>
    <destination-object-name>%message{s3-dest-key}</destination-object-name>
    <object-metadata>
     <s3-serverside-encryption>
      <algorithm>AES_256</algorithm>
     </s3-serverside-encryption>
    </object-metadata>
   </operation>
  </amazon-s3-service>
```

Note that if testing against localstack : 
Copying with "additional defined tags" doesn't seem to work, but if you tag the object first, and then copy with extended-copy then the tags are propagated... (the paths are logically the same).
