### PR TITLE
INTERLOK-3381 Remove deprecated items

### DIFF
--- a/interlok-aws-common/src/main/java/com/adaptris/aws/AWSConnection.java
+++ b/interlok-aws-common/src/main/java/com/adaptris/aws/AWSConnection.java
@@ -21,9 +21,7 @@ import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
-import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisConnectionImp;
-import com.adaptris.core.util.LoggingHelper;
 import com.adaptris.util.KeyValuePairSet;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.regions.DefaultAwsRegionProviderChain;
@@ -34,24 +32,17 @@ public abstract class AWSConnection extends AdaptrisConnectionImp {
 
   /**
    * Set the region for the client.
-   * 
+   *
    * <p>
    * If the region is not specified, then {@link DefaultAwsRegionProviderChain} is used to determine
    * the region. You can always specify a region using the standard system property {@code aws.region}
    * or via environment variables.
    * </p>
-   * 
+   *
    */
   @Getter
   @Setter
   private String region;
-
-  @Valid
-  @Deprecated
-  @Removal(version = "3.11.0", message = "Use a AWSCredentialsProviderBuilder instead")
-  @Getter
-  @Setter
-  private AWSAuthentication authentication;
 
   /**
    * How to provide Credentials for AWS.
@@ -67,7 +58,7 @@ public abstract class AWSConnection extends AdaptrisConnectionImp {
 
   /**
    * Any specific client configuration.
-   * 
+   *
    */
   @Valid
   @AdvancedConfig
@@ -77,7 +68,7 @@ public abstract class AWSConnection extends AdaptrisConnectionImp {
 
   /**
    * The Retry policy.
-   * 
+   *
    */
   @Valid
   @AdvancedConfig
@@ -104,8 +95,7 @@ public abstract class AWSConnection extends AdaptrisConnectionImp {
 
   @SuppressWarnings("deprecation")
   public AWSCredentialsProviderBuilder credentialsProvider() {
-    return AWSCredentialsProviderBuilder.providerWithWarning(LoggingHelper.friendlyName(this), getAuthentication(),
-        getCredentials());
+    return AWSCredentialsProviderBuilder.defaultIfNull(getCredentials());
   }
 
   public KeyValuePairSet clientConfiguration() {
@@ -115,12 +105,12 @@ public abstract class AWSConnection extends AdaptrisConnectionImp {
   public RetryPolicyFactory retryPolicy() {
     return ObjectUtils.defaultIfNull(getRetryPolicy(), new DefaultRetryPolicyFactory());
   }
-  
+
   public <T extends AWSConnection> T withCustomEndpoint(CustomEndpoint endpoint) {
     setCustomEndpoint(endpoint);
     return (T) this;
   }
-  
+
   public <T extends AWSConnection> T withCredentialsProviderBuilder(AWSCredentialsProviderBuilder builder) {
     setCredentials(builder);
     return (T) this;
@@ -142,13 +132,13 @@ public abstract class AWSConnection extends AdaptrisConnectionImp {
   }
 
   /** Returns something that can configure a normal AWS builder with a custom endpoint or a region...
-   * 
+   *
    */
   protected EndpointBuilder endpointBuilder(){
     return getCustomEndpoint() != null && getCustomEndpoint().isConfigured() ? getCustomEndpoint()
         : new RegionOnly();
   }
-  
+
 
 
   protected class RegionOnly implements EndpointBuilder {
@@ -161,6 +151,6 @@ public abstract class AWSConnection extends AdaptrisConnectionImp {
       }
       return builder;
     }
-    
+
   }
 }

--- a/interlok-aws-common/src/main/java/com/adaptris/aws/AWSCredentialsProviderBuilder.java
+++ b/interlok-aws-common/src/main/java/com/adaptris/aws/AWSCredentialsProviderBuilder.java
@@ -1,8 +1,6 @@
 package com.adaptris.aws;
 
 import org.apache.commons.lang3.ObjectUtils;
-import com.adaptris.annotation.Removal;
-import com.adaptris.core.util.LoggingHelper;
 import com.amazonaws.auth.AWSCredentialsProvider;
 
 @FunctionalInterface
@@ -10,23 +8,8 @@ public interface AWSCredentialsProviderBuilder {
 
   AWSCredentialsProvider build() throws Exception;
 
-  /**
-   * Helper to log warnings when configuration contains an {@link AWSAuthentication} member rather
-   * than a {@link AWSCredentialsProviderBuilder}.
-   * 
-   * @deprecated will be removed as soon as {@link AWSAuthentication} is removed from various
-   *             connections.
-   */
-  @Deprecated
-  @Removal(message = "will be removed in a future release w/o warning")
-  static AWSCredentialsProviderBuilder providerWithWarning(String source, AWSAuthentication auth,
-      AWSCredentialsProviderBuilder builder) {
-    if (auth != null) {
-      LoggingHelper.logWarning(false, () -> {
-      }, "authentication is deprecated in {}; use a AWSCredentialsProviderBuilder instead", source);
-      return new StaticCredentialsBuilder().withAuthentication(auth);
-    }
-    return ObjectUtils.defaultIfNull(builder, new StaticCredentialsBuilder().withAuthentication(new DefaultAWSAuthentication()));
+  static AWSCredentialsProviderBuilder defaultIfNull(AWSCredentialsProviderBuilder builder) {
+    return ObjectUtils.defaultIfNull(builder,
+        new StaticCredentialsBuilder().withAuthentication(new DefaultAWSAuthentication()));
   }
-
 }

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/AwsConnectionTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/AwsConnectionTest.java
@@ -24,16 +24,11 @@ public class AwsConnectionTest extends AWSConnection {
   @Test
   @SuppressWarnings("deprecation")
   public void testAuthentication() {
-    assertNull(getAuthentication());
     assertNull(getCredentials());
     assertNotNull(credentialsProvider());
     assertEquals(StaticCredentialsBuilder.class, credentialsProvider().getClass());
-    setAuthentication(new AWSKeysAuthentication("accessKey", "secretKey"));
-    assertNotNull(getAuthentication());
     assertNull(getCredentials());
     assertEquals(StaticCredentialsBuilder.class, credentialsProvider().getClass());    
-    assertEquals(AWSKeysAuthentication.class, ((StaticCredentialsBuilder) credentialsProvider()).getAuthentication().getClass());
-    setAuthentication(null);
     withCredentialsProviderBuilder(new StaticCredentialsBuilder().withAuthentication(new DefaultAWSAuthentication()));
     assertEquals(StaticCredentialsBuilder.class, credentialsProvider().getClass());
     assertEquals(DefaultAWSAuthentication.class, ((StaticCredentialsBuilder) credentialsProvider()).getAuthentication().getClass());

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3BucketList.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3BucketList.java
@@ -32,7 +32,7 @@ import lombok.Setter;
  * {@code %message} expression language; they will, however, be passed as-is into the underlying
  * service (which may still resolve them).
  * </p>
- * 
+ *
  * @config s3-bucket-list
  */
 @XStreamAlias("s3-bucket-list")
@@ -50,7 +50,7 @@ public class S3BucketList extends ServiceImp implements DynamicPollingTemplate.T
 
   /**
    * The S3 bucket to connect to.
-   * 
+   *
    */
   @NotBlank
   @Setter
@@ -60,7 +60,7 @@ public class S3BucketList extends ServiceImp implements DynamicPollingTemplate.T
 
   /**
    * The S3 key to perform a list operation on.
-   * 
+   *
    */
   @AdvancedConfig(rare = true)
   @Setter
@@ -71,7 +71,7 @@ public class S3BucketList extends ServiceImp implements DynamicPollingTemplate.T
 
   /**
    * The prefix to use when issuing the listOperation
-   * 
+   *
    */
   @Setter
   @Getter
@@ -79,7 +79,7 @@ public class S3BucketList extends ServiceImp implements DynamicPollingTemplate.T
 
   /**
    * Specify any additional filtering you wish to perform on the list.
-   * 
+   *
    */
   @Getter
   @Setter
@@ -98,7 +98,7 @@ public class S3BucketList extends ServiceImp implements DynamicPollingTemplate.T
   @Getter
   @Setter
   @Deprecated
-  @Removal(version = "3.11.0",
+  @Removal(version = "4.0",
       message = "due to interface changes; paging results is not explicitly configurable and will be ignored")
   private Boolean pageResults;
 
@@ -133,7 +133,7 @@ public class S3BucketList extends ServiceImp implements DynamicPollingTemplate.T
 
   @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
-    S3Service service = buildService(); 
+    S3Service service = buildService();
     try {
       LifecycleHelper.initAndStart(service, false);
       service.doService(msg);
@@ -149,13 +149,6 @@ public class S3BucketList extends ServiceImp implements DynamicPollingTemplate.T
     return this;
   }
 
-  @Deprecated
-  @Removal(version = "3.11.0",
-      message = "due to interface changes; paging results is not explicitly configurable and will be ignored")
-  public S3BucketList withPageResults(Boolean b) {
-    setPageResults(b);
-    return this;
-  }
 
   @Deprecated
   @Removal(version = "3.12.0", message = "Use prefix instead")

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/BucketListTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/BucketListTest.java
@@ -170,7 +170,7 @@ public class BucketListTest {
     Mockito.when(client.listObjectsV2(argument.capture())).thenReturn(listing, listing2);
 
     S3BucketList bucket =
-        new S3BucketList().withConnection(mockConnection).withPageResults(true)
+        new S3BucketList().withConnection(mockConnection)
             .withPrefix("srcKeyPrefix").withMaxKeys(2)
             .withOutputStyle(null).withBucket("srcBucket");
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/LocalstackServiceTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/LocalstackServiceTest.java
@@ -18,7 +18,6 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ServiceCase;
 import com.adaptris.core.ServiceException;
-import com.adaptris.core.common.ConstantDataInputParameter;
 import com.adaptris.core.metadata.NoOpMetadataFilter;
 import com.adaptris.core.metadata.RegexMetadataFilter;
 import com.adaptris.core.util.PropertyHelper;
@@ -129,19 +128,6 @@ public class LocalstackServiceTest {
     ServiceCase.execute(s1, AdaptrisMessageFactory.getDefaultInstance().newMessage());
   }
 
-
-  @Test
-  @SuppressWarnings("deprecation")
-  public void test_08_List_Legacy() throws Exception {
-    ListOperation ls = new ListOperation()
-        .withFilterSuffix(new ConstantDataInputParameter(getConfig(S3_FILTER_SUFFIX)))
-        .withPrefix(null)
-        .withBucket(getConfig(S3_BUCKETNAME));
-    S3Service service = build(ls);
-    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-    ServiceCase.execute(service, msg);
-    assertEquals(config.getProperty(S3_UPLOAD_FILENAME) + System.lineSeparator(), msg.getContent());
-  }
 
   @Test
   public void test_09_List() throws Exception {

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/MockedOperationTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/MockedOperationTest.java
@@ -369,29 +369,6 @@ public class MockedOperationTest {
 
 
   @Test
-  public void testListOperation_LegacyFilter() throws Exception {
-    AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
-    TransferManager transferManager = Mockito.mock(TransferManager.class);
-    ListObjectsV2Result result = Mockito.mock(ListObjectsV2Result.class);
-    S3ObjectSummary sbase = createSummary("srcBucket", "srcKeyPrefix/");
-    S3ObjectSummary s1 = createSummary("srcBucket", "srcKeyPrefix/file.json");
-    S3ObjectSummary s2 = createSummary("srcBucket", "srcKeyPrefix/file2.csv");
-
-    List<S3ObjectSummary> list = new ArrayList<>(Arrays.asList(sbase, s1, s2));
-    Mockito.when(result.getObjectSummaries()).thenReturn(list);
-    Mockito.when(client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(result);
-    ListOperation ls = new ListOperation()
-        .withFilterSuffix(new ConstantDataInputParameter(".json"))
-        .withPageResults(true)
-        .withBucketName(new ConstantDataInputParameter("srcBucket")).withKey(new ConstantDataInputParameter("srcKeyPrefix/"));
-
-    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("");
-    ClientWrapper wrapper = new ClientWrapperImpl(client, transferManager);
-    execute(ls, wrapper, msg);
-    assertEquals("srcKeyPrefix/file.json" + System.lineSeparator(), msg.getContent());
-  }
-
-  @Test
   public void testListOperation_RemoteBlobFilter() throws Exception {
     AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
     TransferManager transferManager = Mockito.mock(TransferManager.class);

--- a/interlok-aws-sqs/src/main/java/com/adaptris/aws/sqs/jms/AdvancedSQSImplementation.java
+++ b/interlok-aws-sqs/src/main/java/com/adaptris/aws/sqs/jms/AdvancedSQSImplementation.java
@@ -21,6 +21,7 @@ import javax.validation.constraints.NotNull;
 import org.apache.commons.lang3.ObjectUtils;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
+import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.aws.ClientConfigurationBuilder;
 import com.adaptris.aws.CustomEndpoint;
 import com.adaptris.aws.DefaultRetryPolicyFactory;
@@ -45,7 +46,7 @@ import lombok.Setter;
  * property. So if you wanted to control the user-agent you would configure
  * </p>
  * <pre>
- * {@code 
+ * {@code
  *   <client-configuration-properties>
  *     <key-value-pair>
  *        <key>UserAgent</key>
@@ -54,16 +55,17 @@ import lombok.Setter;
  *   </client-configuration-properties>
  * }
  * </pre>
- * 
+ *
  * @config advanced-amazon-sqs-implementation
  * @since 3.2.1
  */
 @XStreamAlias("advanced-amazon-sqs-implementation")
+@DisplayOrder(order = {"region", "prefetchCount", "credentials"})
 public class AdvancedSQSImplementation extends AmazonSQSImplementation {
 
   /**
    * Any other properties you wish to set on the client.
-   * 
+   *
    * @see ClientConfigurationBuilder
    */
   @NotNull
@@ -76,7 +78,7 @@ public class AdvancedSQSImplementation extends AmazonSQSImplementation {
 
   /**
    * The retry policy if required.
-   * 
+   *
    */
   @AdvancedConfig
   @Valid
@@ -92,14 +94,14 @@ public class AdvancedSQSImplementation extends AmazonSQSImplementation {
    * Explicitly configuring this means that your {@link #setRegion(String)} will have no effect (i.e.
    * {@code AwsClientBuilder#setRegion(String)} will never be invoked.
    * </p>
-   * 
+   *
    */
   @Valid
   @AdvancedConfig
   @Getter
   @Setter
   private CustomEndpoint customEndpoint;
-    
+
   public AdvancedSQSImplementation() {
     setClientConfigurationProperties(new KeyValuePairSet());
   }
@@ -109,18 +111,18 @@ public class AdvancedSQSImplementation extends AmazonSQSImplementation {
     return ClientConfigurationBuilder.build(getClientConfigurationProperties())
         .withRetryPolicy(retryPolicy());
   }
-  
+
   @Override
   protected EndpointBuilder endpointBuilder(){
     return getCustomEndpoint() != null && getCustomEndpoint().isConfigured() ? getCustomEndpoint()
         : new RegionOnly();
   }
-  
+
   public AdvancedSQSImplementation withCustomEndpoint(CustomEndpoint endpoint) {
     setCustomEndpoint(endpoint);
     return this;
   }
-  
+
   RetryPolicy retryPolicy() throws Exception {
     return ObjectUtils.defaultIfNull(getRetryPolicy(), new DefaultRetryPolicyFactory()).build();
   }

--- a/interlok-aws-sqs/src/main/java/com/adaptris/aws/sqs/jms/AmazonSQSImplementation.java
+++ b/interlok-aws-sqs/src/main/java/com/adaptris/aws/sqs/jms/AmazonSQSImplementation.java
@@ -23,9 +23,8 @@ import javax.validation.constraints.NotNull;
 import org.apache.commons.lang3.StringUtils;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
+import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
-import com.adaptris.annotation.Removal;
-import com.adaptris.aws.AWSAuthentication;
 import com.adaptris.aws.AWSCredentialsProviderBuilder;
 import com.adaptris.aws.ClientConfigurationBuilder;
 import com.adaptris.aws.EndpointBuilder;
@@ -52,35 +51,29 @@ import lombok.Setter;
  * This VendorImplementation uses the Amazon SQS JMS compatibility layer. When using this class, do not use the AmazonSQS Producer
  * and Consumer classes. Use regular JMS consumers and producers instead.
  * </p>
- * 
+ *
  * @config amazon-sqs-implementation
  * @since 3.0.3
  */
 @XStreamAlias("amazon-sqs-implementation")
+@DisplayOrder(order = {"region", "prefetchCount", "credentials"})
 public class AmazonSQSImplementation extends VendorImplementationImp {
 
   private static int DEFAULT_PREFETCH_COUNT = 10;
 
   /**
    * Set the region for the client.
-   * 
+   *
    * <p>
    * If the region is not specified, then {@link DefaultAwsRegionProviderChain} is used to determine
    * the region. You can always specify a region using the standard system property {@code aws.region}
    * or via environment variables.
    * </p>
-   * 
+   *
    */
   @Getter
   @Setter
   private String region;
-
-  @Valid
-  @Deprecated
-  @Removal(version = "3.11.0", message = "Use a AWSCredentialsProviderBuilder instead")
-  @Getter
-  @Setter
-  private AWSAuthentication authentication;
 
   /**
    * How to provide Credentials for AWS.
@@ -97,7 +90,7 @@ public class AmazonSQSImplementation extends VendorImplementationImp {
 
   /**
    * The maximum number of messages to retrieve from the Amazon SQS queue per request.
-   * 
+   *
    */
   @AdvancedConfig
   @Getter
@@ -107,7 +100,7 @@ public class AmazonSQSImplementation extends VendorImplementationImp {
 
   /**
    * How to create the SQS client and set parameters.
-   * 
+   *
    */
   @NotNull
   @AutoPopulated
@@ -117,7 +110,7 @@ public class AmazonSQSImplementation extends VendorImplementationImp {
   @Setter
   @NonNull
   private SQSClientFactory sqsClientFactory;
-  
+
   private transient SQSConnectionFactory connectionFactory = null;
 
   public AmazonSQSImplementation() {
@@ -147,7 +140,7 @@ public class AmazonSQSImplementation extends VendorImplementationImp {
 
   @SuppressWarnings("deprecation")
   protected AWSCredentialsProviderBuilder credentialsProvider() {
-    return AWSCredentialsProviderBuilder.providerWithWarning(getClass().getCanonicalName(), getAuthentication(), getCredentials());
+    return AWSCredentialsProviderBuilder.defaultIfNull(getCredentials());
   }
 
 
@@ -161,18 +154,11 @@ public class AmazonSQSImplementation extends VendorImplementationImp {
   }
 
 
-  @Deprecated
-  @Removal(version = "3.11.0")
-  public <T extends AmazonSQSImplementation> T withAuthentication(AWSAuthentication a) {
-    setAuthentication(a);
-    return (T) this;
-  }
-  
   public <T extends AmazonSQSImplementation> T withClientFactory(SQSClientFactory fac) {
     setSqsClientFactory(fac);
     return (T) this;
   }
-  
+
 
   public <T extends AmazonSQSImplementation> T withCredentialsProviderBuilder(AWSCredentialsProviderBuilder builder) {
     setCredentials(builder);
@@ -183,11 +169,11 @@ public class AmazonSQSImplementation extends VendorImplementationImp {
   protected EndpointBuilder endpointBuilder() {
     return new RegionOnly();
   }
-  
+
   protected ProviderConfiguration newProviderConfiguration() {
     return new ProviderConfiguration().withNumberOfMessagesToPrefetch(prefetchCount());
   }
-  
+
   protected class RegionOnly implements EndpointBuilder {
 
     @Override
@@ -198,6 +184,6 @@ public class AmazonSQSImplementation extends VendorImplementationImp {
       }
       return builder;
     }
-    
+
   }
 }

--- a/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/jms/AmazonSQSImplementationTest.java
+++ b/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/jms/AmazonSQSImplementationTest.java
@@ -74,17 +74,11 @@ public class AmazonSQSImplementationTest {
   public void testAuthentication() throws Exception {
     AmazonSQSImplementation jmsImpl = createImpl();
 
-    assertNull(jmsImpl.getAuthentication());
     assertNull(jmsImpl.getCredentials());
     assertNotNull(jmsImpl.credentialsProvider());
     assertEquals(StaticCredentialsBuilder.class, jmsImpl.credentialsProvider().getClass());
-    jmsImpl.withAuthentication(new AWSKeysAuthentication("accessKey", "secretKey"));
-    assertNotNull(jmsImpl.getAuthentication());
     assertNull(jmsImpl.getCredentials());
     assertEquals(StaticCredentialsBuilder.class, jmsImpl.credentialsProvider().getClass());
-    assertEquals(AWSKeysAuthentication.class,
-        ((StaticCredentialsBuilder) jmsImpl.credentialsProvider()).getAuthentication().getClass());
-    jmsImpl.setAuthentication(null);
     jmsImpl.withCredentialsProviderBuilder(new StaticCredentialsBuilder().withAuthentication(new DefaultAWSAuthentication()));
     assertEquals(StaticCredentialsBuilder.class, jmsImpl.credentialsProvider().getClass());
     assertEquals(DefaultAWSAuthentication.class,


### PR DESCRIPTION
## Motivation

Removing things marked for removal in 3.11.0

## Modification

- Remove aws-authentication as a top-level item in various Connections along with a change to remove the static method in AWSCredentialsProviderBuilder interface.
- PageResults in s3/list has a stay of execution since it was only deprecated in 3.10.2.
- Remove suffix from S3 list operations.

## Result

Users that haven't been paying attention are broken.
