### PR TITLE
INTERLOK-3465 S3 RetryStore Impl

### DIFF
--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/retry/RetryableBlobIterable.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/retry/RetryableBlobIterable.java
@@ -1,0 +1,41 @@
+package com.adaptris.aws.s3.retry;
+
+import java.util.Iterator;
+import java.util.function.Function;
+import com.adaptris.interlok.cloud.RemoteBlob;
+
+class RetryableBlobIterable implements Iterable<RemoteBlob>, Iterator<RemoteBlob> {
+
+  private transient Iterator<RemoteBlob> wrappedIterator;
+  private transient Iterable<RemoteBlob> wrappedIterable;
+  private transient Function<String, String> nameMapper;
+
+  public RetryableBlobIterable(Iterable<RemoteBlob> itr, Function<String, String> msgIdFunction) {
+    wrappedIterable = itr;
+    nameMapper = msgIdFunction;
+  }
+
+  @Override
+  public Iterator<RemoteBlob> iterator() {
+    if (wrappedIterator != null) {
+      throw new IllegalStateException("iterator already invoked");
+    }
+    wrappedIterator = wrappedIterable.iterator();
+    return this;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return wrappedIterator.hasNext();
+  }
+
+  @Override
+  public RemoteBlob next() {
+    RemoteBlob blob = wrappedIterator.next();
+    // Leave the bucket as null so that it is not rendered (or rendered as null.
+    return new RemoteBlob.Builder()
+        .setLastModified(blob.getLastModified()).setName(nameMapper.apply(blob.getName()))
+        .setSize(blob.getSize()).build();
+  }
+
+}

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/retry/S3RetryStore.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/retry/S3RetryStore.java
@@ -1,0 +1,253 @@
+package com.adaptris.aws.s3.retry;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.aws.s3.AmazonS3Connection;
+import com.adaptris.aws.s3.ClientWrapper;
+import com.adaptris.aws.s3.RemoteBlobIterable;
+import com.adaptris.aws.s3.UploadOperation;
+import com.adaptris.core.AdaptrisConnection;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.MetadataCollection;
+import com.adaptris.core.http.jetty.retry.RetryStore;
+import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.core.util.LifecycleHelper;
+import com.adaptris.interlok.InterlokException;
+import com.adaptris.interlok.cloud.RemoteBlob;
+import com.adaptris.interlok.util.Args;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.S3Object;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ *
+ * @config amazon-s3-retry-store
+ *
+ */
+@XStreamAlias("amazon-s3-retry-store")
+@ComponentProfile(summary = "Supporting implementation for using S3 as your failed message store",
+    tag = "retry,amazon,s3", since = "3.11.1", recommended = {AmazonS3Connection.class})
+@NoArgsConstructor
+@Slf4j
+public class S3RetryStore implements RetryStore {
+
+  protected static final String PAYLOAD_FILE_NAME = "payload.blob";
+  protected static final String METADATA_FILE_NAME = "metadata.properties";
+
+  /**
+   * Set the connection to use to connect to S3.
+   *
+   */
+  @Valid
+  @Getter
+  @Setter
+  @NotNull
+  @NonNull
+  private AdaptrisConnection connection;
+  @Getter
+  @Setter
+  @NotBlank
+  private String bucket;
+  @Getter
+  @Setter
+  private String prefix;
+
+  private transient Pattern nameMapper = null;
+
+  @Override
+  public void prepare() throws CoreException {
+    Args.notBlank(bucket, "bucket");
+    LifecycleHelper.prepare(getConnection());
+  }
+
+  @Override
+  public void init() throws CoreException {
+    nameMapper = Pattern.compile(payloadBlobRegexp());
+    LifecycleHelper.init(getConnection());
+
+  }
+
+  @Override
+  public void start() throws CoreException {
+    LifecycleHelper.start(getConnection());
+
+  }
+
+  @Override
+  public void stop() {
+    LifecycleHelper.stop(getConnection());
+
+  }
+
+  @Override
+  public void close() {
+    LifecycleHelper.close(getConnection());
+  }
+
+  public S3RetryStore withConnection(AdaptrisConnection c) {
+    setConnection(c);
+    return this;
+  }
+
+
+  public S3RetryStore withPrefix(String s) {
+    setPrefix(s);
+    return this;
+  }
+
+
+  public S3RetryStore withBucket(String s) {
+    setBucket(s);
+    return this;
+  }
+
+  // Listing files is a little trickier since a ListObjectsRequest based on the configured
+  // prefix gives us everything (not just the msg-id directories).
+  // Filter on things that end with the required name 'payload.blob'
+  // If the corresponding msg-id/metadata.properties doesn't exist, then it'll fail when we
+  // attempt to retry it.
+  @Override
+  public Iterable<RemoteBlob> report() throws InterlokException {
+    AmazonS3Client s3 = clientWrapper().amazonClient();
+    ListObjectsV2Request request =
+        new ListObjectsV2Request().withBucketName(getBucket()).withPrefix(getPrefix());
+    return new RetryableBlobIterable(
+        new RemoteBlobIterable(s3, request, (blob) -> blob.getName().endsWith(PAYLOAD_FILE_NAME)),
+        (name) -> toMessageID(name));
+  }
+
+  @Override
+  public boolean delete(String msgId) throws InterlokException {
+    String payloadName = buildObjectName(msgId, PAYLOAD_FILE_NAME);
+    String metadataName = buildObjectName(msgId, METADATA_FILE_NAME);
+    log.trace("Deleting {} from bucket {}", metadataName, getBucket());
+    clientWrapper().amazonClient().deleteObject(getBucket(), metadataName);
+    log.trace("Deleting {} from bucket {}", payloadName, getBucket());
+    clientWrapper().amazonClient().deleteObject(getBucket(), payloadName);
+    return true;
+  }
+
+  @Override
+  public void write(AdaptrisMessage msg) throws InterlokException {
+    try {
+      String blob = buildObjectName(msg.getUniqueId(), PAYLOAD_FILE_NAME);
+      String metadata = buildObjectName(msg.getUniqueId(), METADATA_FILE_NAME);
+
+      UploadOperation payloadUpload = uploader(blob);
+      log.trace("Uploading {} to bucket {}", blob, getBucket());
+      payloadUpload.execute(clientWrapper(), msg);
+
+      UploadOperation metadataUpload = uploader(metadata);
+      AdaptrisMessage metadataMsg = metadataAsMessage(msg);
+      log.trace("Uploading {} to bucket {}", metadata, getBucket());
+      metadataUpload.execute(clientWrapper(), metadataMsg);
+
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapInterlokException(e);
+    }
+
+  }
+
+  @Override
+  public AdaptrisMessage buildForRetry(String msgId, Map<String, String> metadata,
+      AdaptrisMessageFactory factory) throws InterlokException {
+    try {
+      String payloadName = buildObjectName(msgId, PAYLOAD_FILE_NAME);
+      AdaptrisMessage msg = AdaptrisMessageFactory.defaultIfNull(factory).newMessage();
+      try (InputStream in = getInputStream(payloadName); OutputStream out = msg.getOutputStream()) {
+        IOUtils.copy(in, out);
+      }
+      msg.setMessageHeaders(metadata);
+      msg.setUniqueId(msgId);
+      return msg;
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapInterlokException(e);
+    }
+  }
+
+  @Override
+  public Map<String, String> getMetadata(String msgId) throws InterlokException {
+    try {
+      String metadataName = buildObjectName(msgId, METADATA_FILE_NAME);
+      Properties meta = new Properties();
+      try (InputStream in = getInputStream(metadataName)) {
+        meta.load(in);
+      }
+      // The compiler works in mysterious ways.
+      return (Map) meta;
+    } catch (Exception e) {
+      throw ExceptionHelper.wrapInterlokException(e);
+    }
+  }
+
+  public InputStream getInputStream(String objectName) throws Exception {
+    AmazonS3Client s3 = clientWrapper().amazonClient();
+    GetObjectRequest request = new GetObjectRequest(getBucket(), objectName);
+    log.trace("Getting {} from bucket {}", request.getKey(), request.getBucketName());
+    S3Object response = s3.getObject(request);
+    return response.getObjectContent();
+  }
+
+  private ClientWrapper clientWrapper() {
+    return getConnection().retrieveConnection(ClientWrapper.class);
+  }
+
+  private UploadOperation uploader(String objectName) throws CoreException {
+    UploadOperation op = new UploadOperation().withObjectName(objectName).withBucket(getBucket());
+    // this is called for completeness, since we know we have an object name + bucket...
+    // prepare() is only really required for the legacy migration stuffs.
+    op.prepare();
+    return op;
+  }
+
+  private AdaptrisMessage metadataAsMessage(AdaptrisMessage orig) throws Exception {
+    AdaptrisMessage metadata = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    try (OutputStream out = metadata.getOutputStream()) {
+      Properties p = MetadataCollection.asProperties(orig.getMetadata());
+      p.store(out, "");
+    }
+    return metadata;
+  }
+
+  // Side effect of the way the payloadBlobRegexp is built, regardless
+  // the prefix-less match always matches... so we don't need to have
+  // an if boundary on matches() we just need to call it.
+  String toMessageID(String s) {
+    Matcher m = nameMapper.matcher(s);
+    m.matches();
+    return m.toMatchResult().group(1);
+  }
+
+  String buildObjectName(String msgId, String name) {
+    if (StringUtils.isBlank(getPrefix())) {
+      return String.format("%s/%s", msgId, name);
+    }
+    return String.format("%s/%s/%s", getPrefix(), msgId, name);
+  }
+
+  String payloadBlobRegexp() {
+    if (StringUtils.isBlank(getPrefix())) {
+      return String.format("(.*)/%s", PAYLOAD_FILE_NAME);
+    }
+    return String.format("%s/(.*)/%s", getPrefix(), PAYLOAD_FILE_NAME);
+  }
+}

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/retry/S3RetryStore.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/retry/S3RetryStore.java
@@ -176,6 +176,7 @@ public class S3RetryStore implements RetryStore {
       try (InputStream in = getInputStream(payloadName); OutputStream out = msg.getOutputStream()) {
         IOUtils.copy(in, out);
       }
+      log.trace("Payload for [{}] loaded", msgId);
       msg.setMessageHeaders(metadata);
       msg.setUniqueId(msgId);
       return msg;
@@ -192,6 +193,7 @@ public class S3RetryStore implements RetryStore {
       try (InputStream in = getInputStream(metadataName)) {
         meta.load(in);
       }
+      log.trace("metadata for [{}] loaded", msgId);
       // The compiler works in mysterious ways.
       return (Map) meta;
     } catch (Exception e) {

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/retry/package-info.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/retry/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * {@link com.adaptris.core.http.jetty.retry.RetryStore} implementation.
+ */
+package com.adaptris.aws.s3.retry;

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/LocalstackConfig.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/LocalstackConfig.java
@@ -1,0 +1,55 @@
+package com.adaptris.aws.s3;
+
+import java.util.Properties;
+import org.apache.commons.lang3.BooleanUtils;
+import com.adaptris.aws.AWSKeysAuthentication;
+import com.adaptris.aws.CustomEndpoint;
+import com.adaptris.aws.StaticCredentialsBuilder;
+import com.adaptris.core.util.PropertyHelper;
+
+public class LocalstackConfig {
+
+  public static final String MY_TAG_TEXT = "text";
+  public static final String MY_TAG = "MyTag";
+  public static final String TESTS_ENABLED = "localstack.tests.enabled";
+  public static final String S3_SIGNING_REGION = "localstack.s3.signingRegion";
+  public static final String S3_URL = "localstack.s3.url";
+  public static final String S3_UPLOAD_FILENAME = "localstack.s3.upload.filename";
+  public static final String S3_COPY_TO_FILENAME = "localstack.s3.copy.filename";
+  public static final String S3_BUCKETNAME = "localstack.s3.bucketname";
+  public static final String S3_FILTER_SUFFIX = "localstack.s3.ls.filterSuffix";
+  public static final String S3_FILTER_REGEXP = "localstack.s3.ls.filterRegexp";
+  public static final String S3_RETRY_PREFIX = "localstack.s3.retry.prefix";
+  public static final String S3_RETRY_BUCKET_NAME = "localstack.s3.retry.bucketname";
+
+  public static final String PROPERTIES_RESOURCE = "unit-tests.properties";
+
+  private static Properties config = PropertyHelper.loadQuietly(PROPERTIES_RESOURCE);
+
+  public static String getConfiguration(String s) {
+    return getConfiguration().getProperty(s);
+  }
+
+  public static Properties getConfiguration() {
+    return config;
+  }
+
+  public static boolean areTestsEnabled() {
+    return BooleanUtils.toBoolean(getConfiguration().getProperty(TESTS_ENABLED, "false"));
+  }
+
+  public static S3Service build(S3Operation operation) {
+    return new S3Service(createConnection(), operation);
+  }
+
+  public static AmazonS3Connection createConnection() {
+    String serviceEndpoint = getConfiguration().getProperty(S3_URL);
+    String signingRegion = getConfiguration().getProperty(S3_SIGNING_REGION);
+    AmazonS3Connection connection = new AmazonS3Connection()
+        .withCredentialsProviderBuilder(new StaticCredentialsBuilder()
+            .withAuthentication(new AWSKeysAuthentication("TEST", "TEST")))
+        .withCustomEndpoint(new CustomEndpoint().withServiceEndpoint(serviceEndpoint)
+            .withSigningRegion(signingRegion));
+    return connection;
+  }
+}

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/retry/LocalstackRetryStoreTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/retry/LocalstackRetryStoreTest.java
@@ -1,0 +1,115 @@
+package com.adaptris.aws.s3.retry;
+
+import static com.adaptris.aws.s3.LocalstackConfig.S3_RETRY_BUCKET_NAME;
+import static com.adaptris.aws.s3.LocalstackConfig.S3_RETRY_PREFIX;
+import static com.adaptris.aws.s3.LocalstackConfig.areTestsEnabled;
+import static com.adaptris.aws.s3.LocalstackConfig.build;
+import static com.adaptris.aws.s3.LocalstackConfig.createConnection;
+import static com.adaptris.aws.s3.LocalstackConfig.getConfiguration;
+import static com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase.execute;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import java.util.Iterator;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import com.adaptris.aws.s3.CreateBucketOperation;
+import com.adaptris.aws.s3.DeleteBucketOperation;
+import com.adaptris.aws.s3.S3Service;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.interlok.cloud.RemoteBlob;
+import com.adaptris.interlok.junit.scaffolding.BaseCase;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class LocalstackRetryStoreTest {
+
+  @Before
+  public void setUp() throws Exception {
+    Assume.assumeTrue(areTestsEnabled());
+  }
+
+  @Test
+  public void test_01_CreateBucket() throws Exception {
+    CreateBucketOperation create =
+        new CreateBucketOperation().withBucket(getConfig(S3_RETRY_BUCKET_NAME));
+    S3Service service = build(create);
+    execute(service, AdaptrisMessageFactory.getDefaultInstance().newMessage());
+  }
+
+  @Test
+  public void test_10_Write() throws Exception {
+    S3RetryStore store = new S3RetryStore().withBucket(getConfig(S3_RETRY_BUCKET_NAME))
+        .withPrefix(getConfig(S3_RETRY_PREFIX)).withConnection(createConnection());
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("Hello World");
+    try {
+      BaseCase.start(store);
+      store.write(msg);
+    } finally {
+      BaseCase.stop(store);
+    }
+  }
+
+  @Test
+  public void test_20_Report() throws Exception {
+    S3RetryStore store = new S3RetryStore().withBucket(getConfig(S3_RETRY_BUCKET_NAME))
+        .withPrefix(getConfig(S3_RETRY_PREFIX)).withConnection(createConnection());
+    try {
+      BaseCase.start(store);
+      Iterable<RemoteBlob> blobs = store.report();
+      Iterator<RemoteBlob> itr = blobs.iterator();
+      assertNotNull(itr);
+      assertTrue(itr.hasNext());
+    } finally {
+      BaseCase.stop(store);
+    }
+  }
+
+  @Test
+  public void test_30_BuildForRetry() throws Exception {
+    S3RetryStore store = new S3RetryStore().withBucket(getConfig(S3_RETRY_BUCKET_NAME))
+        .withPrefix(getConfig(S3_RETRY_PREFIX)).withConnection(createConnection());
+    try {
+      BaseCase.start(store);
+      Iterable<RemoteBlob> blobs = store.report();
+      Iterator<RemoteBlob> itr = blobs.iterator();
+      assertNotNull(itr);
+      assertTrue(itr.hasNext());
+      RemoteBlob blob = itr.next();
+      AdaptrisMessage msg = store.buildForRetry(blob.getName());
+    } finally {
+      BaseCase.stop(store);
+    }
+  }
+
+  @Test
+  public void test_90_Delete() throws Exception {
+    S3RetryStore store = new S3RetryStore().withBucket(getConfig(S3_RETRY_BUCKET_NAME))
+        .withPrefix(getConfig(S3_RETRY_PREFIX)).withConnection(createConnection());
+    try {
+      BaseCase.start(store);
+      Iterable<RemoteBlob> blobs = store.report();
+      for (RemoteBlob blob : blobs) {
+        store.delete(blob.getName());
+      }
+    } finally {
+      BaseCase.stop(store);
+    }
+  }
+
+  @Test
+  public void test_99_DeleteBucket() throws Exception {
+    DeleteBucketOperation delete =
+        new DeleteBucketOperation().withBucket(getConfig(S3_RETRY_BUCKET_NAME));
+    S3Service service = build(delete);
+    execute(service, AdaptrisMessageFactory.getDefaultInstance().newMessage());
+  }
+
+
+  protected String getConfig(String cfgKey) {
+    return getConfiguration().getProperty(cfgKey);
+  }
+
+}

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/retry/RetryableBlobIterableTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/retry/RetryableBlobIterableTest.java
@@ -1,0 +1,42 @@
+package com.adaptris.aws.s3.retry;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
+import org.junit.Test;
+import com.adaptris.interlok.cloud.RemoteBlob;
+
+public class RetryableBlobIterableTest {
+
+  @Test
+  public void testIterator() throws Exception {
+    RetryableBlobIterable itr = new RetryableBlobIterable(build(1), (s) -> nameMapper(s));
+    Iterator<RemoteBlob> i = itr.iterator();
+    assertTrue(i.hasNext());
+    RemoteBlob blob = i.next();
+    assertFalse(blob.getName().startsWith("my-prefix/"));
+
+  }
+  @Test(expected = IllegalStateException.class)
+  public void testIterator_Double() throws Exception {
+    RetryableBlobIterable itr = new RetryableBlobIterable(build(10), (s) -> nameMapper(s));
+    itr.iterator();
+    itr.iterator();
+  }
+
+  private Iterable<RemoteBlob> build(int count) {
+    List<RemoteBlob> result = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      result.add(
+          new RemoteBlob.Builder().setBucket("bucket").setLastModified(System.currentTimeMillis())
+              .setSize(-1).setName("my-prefix/" + UUID.randomUUID().toString()).build());
+    }
+    return result;
+  }
+
+  private String nameMapper(String s) {
+    return s.replace("my-prefix/", "");
+  }
+}

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/retry/S3RetryStoreTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/retry/S3RetryStoreTest.java
@@ -1,0 +1,360 @@
+package com.adaptris.aws.s3.retry;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.junit.Test;
+import org.mockito.Mockito;
+import com.adaptris.aws.s3.AmazonS3Connection;
+import com.adaptris.aws.s3.ClientWrapper;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.interlok.InterlokException;
+import com.adaptris.interlok.cloud.RemoteBlob;
+import com.adaptris.interlok.junit.scaffolding.BaseCase;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.amazonaws.services.s3.transfer.TransferManager;
+import com.amazonaws.services.s3.transfer.TransferProgress;
+import com.amazonaws.services.s3.transfer.Upload;
+
+public class S3RetryStoreTest {
+
+
+  private static final String CLASS_UNDER_TEST_KEY = "ClassUnderTest";
+
+  @Test
+  public void testReport() throws Exception {
+    AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
+    TransferManager transferManager = Mockito.mock(TransferManager.class);
+    ClientWrapper wrapper = Mockito.mock(ClientWrapper.class);
+    Mockito.when(wrapper.amazonClient()).thenReturn(client);
+    Mockito.when(wrapper.transferManager()).thenReturn(transferManager);
+
+    AmazonS3Connection conn = buildConnection(wrapper);
+
+    ListObjectsV2Result result = Mockito.mock(ListObjectsV2Result.class);
+    String msgId1 = UUID.randomUUID().toString();
+    String msgId2 = UUID.randomUUID().toString();
+    S3ObjectSummary sbase = createSummary("bucket", msgId1 + "/payload.blob");
+    S3ObjectSummary s1 = createSummary("bucket", msgId1 + "/metadata.properties");
+    S3ObjectSummary s2 = createSummary("bucket", msgId2 + "/payload.blob");
+    S3ObjectSummary s3 = createSummary("bucket", msgId2 + "/metadata.properties");
+
+    List<S3ObjectSummary> list = new ArrayList<>(
+        Arrays.asList(createSummary("bucket", "MyPrefix/" + msgId1 + "/payload.blob"),
+            createSummary("bucket", "MyPrefix/" + msgId1 + "/metadata.properties"),
+            createSummary("bucket", "MyPrefix/" + msgId2 + "/payload.blob"),
+            createSummary("bucket", "MyPrefix/" + msgId2 + "/metadata.properties")));
+
+    Mockito.when(result.getObjectSummaries()).thenReturn(list);
+    Mockito.when(client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(result);
+
+    S3RetryStore store =
+        new S3RetryStore().withBucket("bucket").withPrefix("MyPrefix").withConnection(conn);
+    try {
+      BaseCase.start(store);
+      Iterable<RemoteBlob> blobs = store.report();
+      List<String> blobNames = StreamSupport.stream(blobs.spliterator(), false)
+          .map((blob) -> blob.getName()).collect(Collectors.toList());
+      assertTrue(blobNames.contains(msgId1));
+      assertTrue(blobNames.contains(msgId2));
+    } finally {
+      BaseCase.stop(store);
+    }
+  }
+
+
+  // Designed to check to toMessageId method and other things that are predicated on getPrefix
+  // it's all about the coverage...
+  @Test
+  public void testPrefix() throws Exception {
+    AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
+    TransferManager transferManager = Mockito.mock(TransferManager.class);
+    ClientWrapper wrapper = Mockito.mock(ClientWrapper.class);
+    Mockito.when(wrapper.amazonClient()).thenReturn(client);
+    Mockito.when(wrapper.transferManager()).thenReturn(transferManager);
+
+    AmazonS3Connection conn = buildConnection(wrapper);
+
+    S3RetryStore store_no_prefix = new S3RetryStore().withBucket("bucket").withConnection(conn);
+    S3RetryStore store_with_prefix =
+        new S3RetryStore().withBucket("bucket").withPrefix("prefix").withConnection(conn);
+    try {
+      BaseCase.start(store_no_prefix, store_with_prefix);
+      assertEquals("prefix/msgId", store_no_prefix.toMessageID("prefix/msgId/payload.blob"));
+      assertEquals("msgId", store_with_prefix.toMessageID("prefix/msgId/payload.blob"));
+
+      assertEquals("msgId/payload.blob", store_no_prefix.buildObjectName("msgId", "payload.blob"));
+      assertEquals("prefix/msgId/payload.blob",
+          store_with_prefix.buildObjectName("msgId", "payload.blob"));
+    } finally {
+      BaseCase.stop(store_no_prefix, store_with_prefix);
+    }
+  }
+
+  @Test
+  public void testWrite() throws Exception {
+    Upload uploadObject = Mockito.mock(Upload.class);
+    TransferProgress progress = new TransferProgress();
+
+    Map<String, String> userMetadata = new HashMap<>();
+    userMetadata.put("hello", "world");
+    Mockito.when(uploadObject.isDone()).thenReturn(false, false, true);
+    Mockito.when(uploadObject.getProgress()).thenReturn(progress);
+    Mockito.doAnswer((i) -> {
+      return null;
+    }).when(uploadObject).waitForCompletion();
+
+    AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
+    TransferManager transferManager = Mockito.mock(TransferManager.class);
+    ClientWrapper wrapper = Mockito.mock(ClientWrapper.class);
+    Mockito.when(wrapper.amazonClient()).thenReturn(client);
+    Mockito.when(wrapper.transferManager()).thenReturn(transferManager);
+
+    AmazonS3Connection conn = buildConnection(wrapper);
+
+    Mockito.when(transferManager.upload(anyString(), anyString(), (InputStream) any(),
+        (ObjectMetadata) any())).thenReturn(uploadObject);
+
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("hello", "UTF-8");
+    msg.addMessageHeader("hello", "world");
+
+    S3RetryStore store =
+        new S3RetryStore().withBucket("bucket").withPrefix("MyPrefix").withConnection(conn);
+    try {
+      BaseCase.start(store);
+      store.write(msg);
+    } finally {
+      BaseCase.stop(store);
+    }
+  }
+
+
+  @Test(expected = InterlokException.class)
+  public void testWrite_Exception() throws Exception {
+
+    AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
+    TransferManager transferManager = Mockito.mock(TransferManager.class);
+    ClientWrapper wrapper = Mockito.mock(ClientWrapper.class);
+    Mockito.when(wrapper.amazonClient()).thenReturn(client);
+    Mockito.when(wrapper.transferManager()).thenReturn(transferManager);
+
+    AmazonS3Connection conn = buildConnection(wrapper);
+
+    Mockito.when(transferManager.upload(anyString(), anyString(), (InputStream) any(),
+        (ObjectMetadata) any())).thenThrow(new RuntimeException());
+
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage("hello", "UTF-8");
+    msg.addMessageHeader("hello", "world");
+
+    S3RetryStore store =
+        new S3RetryStore().withBucket("bucket").withPrefix("MyPrefix").withConnection(conn);
+    try {
+      BaseCase.start(store);
+      store.write(msg);
+    } finally {
+      BaseCase.stop(store);
+    }
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
+    TransferManager transferManager = Mockito.mock(TransferManager.class);
+    ClientWrapper wrapper = Mockito.mock(ClientWrapper.class);
+    Mockito.when(wrapper.amazonClient()).thenReturn(client);
+    Mockito.when(wrapper.transferManager()).thenReturn(transferManager);
+    Mockito.doAnswer((i) -> {
+      return null;
+    }).when(client).deleteObject(anyString(), anyString());
+
+
+    AmazonS3Connection conn = buildConnection(wrapper);
+
+    S3RetryStore store =
+        new S3RetryStore().withBucket("bucket").withPrefix("MyPrefix").withConnection(conn);
+    try {
+      BaseCase.start(store);
+      store.delete("XXXX");
+    } finally {
+      BaseCase.stop(store);
+    }
+  }
+
+
+  @Test
+  public void testGetMetadata() throws Exception {
+    AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
+    TransferManager transferManager = Mockito.mock(TransferManager.class);
+    ClientWrapper wrapper = Mockito.mock(ClientWrapper.class);
+    Mockito.when(wrapper.amazonClient()).thenReturn(client);
+    Mockito.when(wrapper.transferManager()).thenReturn(transferManager);
+
+    S3Object mS3Object = Mockito.mock(S3Object.class);
+    ObjectMetadata objMetadata = Mockito.mock(ObjectMetadata.class);
+    ByteArrayInputStream mStream = createMetadataStream();
+    S3ObjectInputStream resultStream =
+        new S3ObjectInputStream(mStream, null);
+    long size = mStream.available();
+    Mockito.when(objMetadata.getContentLength()).thenReturn(size);
+    Mockito.when(mS3Object.getObjectMetadata()).thenReturn(objMetadata);
+    Mockito.when(mS3Object.getObjectContent()).thenReturn(resultStream);
+    Mockito.when(client.getObject((GetObjectRequest) any())).thenReturn(mS3Object);
+
+    AmazonS3Connection conn = buildConnection(wrapper);
+
+    S3RetryStore store =
+        new S3RetryStore().withBucket("bucket").withPrefix("MyPrefix").withConnection(conn);
+    try {
+      BaseCase.start(store);
+      Map<String, String> map = store.getMetadata("XXXX");
+      assertTrue(map.containsKey(CLASS_UNDER_TEST_KEY));
+    } finally {
+      BaseCase.stop(store);
+    }
+  }
+
+  @Test(expected = InterlokException.class)
+  public void testGetMetadata_Exception() throws Exception {
+    AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
+    TransferManager transferManager = Mockito.mock(TransferManager.class);
+    ClientWrapper wrapper = Mockito.mock(ClientWrapper.class);
+    Mockito.when(wrapper.amazonClient()).thenReturn(client);
+    Mockito.when(wrapper.transferManager()).thenReturn(transferManager);
+
+    Mockito.when(client.getObject((GetObjectRequest) any()))
+        .thenThrow(new RuntimeException());
+
+    AmazonS3Connection conn = buildConnection(wrapper);
+
+    S3RetryStore store =
+        new S3RetryStore().withBucket("bucket").withPrefix("MyPrefix").withConnection(conn);
+    try {
+      BaseCase.start(store);
+      Map<String, String> map = store.getMetadata("XXXX");
+      assertTrue(map.containsKey(CLASS_UNDER_TEST_KEY));
+    } finally {
+      BaseCase.stop(store);
+    }
+  }
+
+  @Test
+  public void testBuildForRetry() throws Exception {
+    AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
+    TransferManager transferManager = Mockito.mock(TransferManager.class);
+    ClientWrapper wrapper = Mockito.mock(ClientWrapper.class);
+    Mockito.when(wrapper.amazonClient()).thenReturn(client);
+    Mockito.when(wrapper.transferManager()).thenReturn(transferManager);
+
+    S3Object pS3Object = Mockito.mock(S3Object.class);
+    ObjectMetadata objMetadata = Mockito.mock(ObjectMetadata.class);
+    ByteArrayInputStream pStream =
+        new ByteArrayInputStream("hello world".getBytes(StandardCharsets.UTF_8));
+    S3ObjectInputStream resultStream = new S3ObjectInputStream(pStream, null);
+    long size = pStream.available();
+    Mockito.when(objMetadata.getContentLength()).thenReturn(size);
+    Mockito.when(pS3Object.getObjectMetadata()).thenReturn(objMetadata);
+    Mockito.when(pS3Object.getObjectContent()).thenReturn(resultStream);
+    Mockito.when(client.getObject((GetObjectRequest) any())).thenReturn(pS3Object);
+
+    AmazonS3Connection conn = buildConnection(wrapper);
+
+    S3RetryStore store =
+        new S3RetryStore().withBucket("bucket").withPrefix("MyPrefix").withConnection(conn);
+    try {
+      BaseCase.start(store);
+      Map<String, String> metadata = new HashMap<>();
+      metadata.put(CLASS_UNDER_TEST_KEY, S3RetryStore.class.getCanonicalName());
+      String expectedGuid = UUID.randomUUID().toString();
+      AdaptrisMessage msg = store.buildForRetry(expectedGuid, metadata, null);
+      assertEquals(expectedGuid, msg.getUniqueId());
+      assertTrue(msg.headersContainsKey(CLASS_UNDER_TEST_KEY));
+      assertEquals(S3RetryStore.class.getCanonicalName(),
+          msg.getMetadataValue(CLASS_UNDER_TEST_KEY));
+    } finally {
+      BaseCase.stop(store);
+    }
+  }
+
+  @Test(expected = InterlokException.class)
+  public void testBuildForRetry_Failure() throws Exception {
+    AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
+    TransferManager transferManager = Mockito.mock(TransferManager.class);
+    ClientWrapper wrapper = Mockito.mock(ClientWrapper.class);
+    Mockito.when(wrapper.amazonClient()).thenReturn(client);
+    Mockito.when(wrapper.transferManager()).thenReturn(transferManager);
+
+    Mockito.when(client.getObject((GetObjectRequest) any())).thenThrow(new RuntimeException());
+
+    AmazonS3Connection conn = buildConnection(wrapper);
+
+    S3RetryStore store =
+        new S3RetryStore().withBucket("bucket").withPrefix("MyPrefix").withConnection(conn);
+    try {
+      BaseCase.start(store);
+      Map<String, String> metadata = new HashMap<>();
+      AdaptrisMessage msg = store.buildForRetry("XXX", metadata, null);
+    } finally {
+      BaseCase.stop(store);
+    }
+  }
+
+  private AmazonS3Connection buildConnection(ClientWrapper wrapper) {
+    AmazonS3Connection connection = Mockito.mock(AmazonS3Connection.class);
+    Mockito.when(connection.retrieveConnection(ClientWrapper.class)).thenReturn(wrapper);
+    return connection;
+  }
+
+  public static S3ObjectSummary createSummary(String bucket, String key) {
+    S3ObjectSummary sbase = new S3ObjectSummary();
+    sbase.setBucketName(bucket);
+    sbase.setKey(key);
+    sbase.setSize(0);
+    sbase.setLastModified(new Date());
+    return sbase;
+  }
+
+  private Properties createProperties() {
+    Properties p = new Properties();
+    p.putAll(System.getenv());
+    p.setProperty(CLASS_UNDER_TEST_KEY, S3RetryStore.class.getCanonicalName());
+    return p;
+  }
+
+  private ByteArrayInputStream createMetadataStream() throws IOException {
+    return createInputStream(createProperties());
+  }
+
+  private ByteArrayInputStream createInputStream(Properties p) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    try (OutputStream o = out) {
+      p.store(out, "");
+    }
+    return new ByteArrayInputStream(out.toByteArray());
+  }
+}

--- a/interlok-aws-s3/src/test/resources/unit-tests.properties.template
+++ b/interlok-aws-s3/src/test/resources/unit-tests.properties.template
@@ -11,3 +11,5 @@ junit.localstack.s3.copy.filename=goodbye.txt
 junit.localstack.s3.tmp.dir=@BUILD_DIR@/tmp
 junit.localstack.s3.ls.filterSuffix=.txt
 junit.localstack.s3.ls.filterRegexp=.*\\.txt
+junit.localstack.s3.retry.prefix=zzlc/retry
+junit.localstack.s3.retry.bucketname=retrybucket


### PR DESCRIPTION
## Motivation

This is the AWS-S3 implementation for https://github.com/adaptris/interlok/blob/develop/docs/adr/0008-restful-failed-message-retrier.md

The intention is to have a pluggable s3-retry-store implementation that duplicates the reference filesystem behaviour made available as part of https://github.com/adaptris/interlok/pull/556. 

## Modification

- Added a S3RetryStore implementation
- Refactor the localstack tests to expose shared functionality
- Mockito based tests for 100% coverage.
- Change the existing behaviour in interlok-json (https://github.com/adaptris/interlok-json/commit/43e0bb11a3251c0082d71ea5f964088aeb50d60e) so that bucket is not emitted if it's null.
- Change the existing behaviour in interlok-core (https://github.com/adaptris/interlok/commit/0cb7262102273c46acc3c070a5340b8b90fd05b3) so that we don't emit the bucket.
- The layout duplicates that of the filesystem-retry-store, so separate metadata.properties / payload.blob; and handles the AWS nuance around _trying to think about prefixes as directories even though they aren't_

The rationale behind not emitting the bucket is to remove any ambiguity around what's returned by the `report()` operation. We don't expose anything information other than _what could be retried via the jetty-retrier_... rather than letting people know about buckets / directories (since we drop the prefix when doing the S3 report).

## Result

- `amazon-s3-retry-store` is now selectable as a retry store implementation; (requires 3.11-SNAPSHOT).
- RemoteBlobIterable is now a public class not package level (though it possibly doesn't need to be).

## Testing

Based on the configuration detailed in : https://github.com/adaptris/interlok/pull/556 we should be able to do this

- Add amazon-s3 as a shared connection
```xml
      <amazon-s3-connection>
        <unique-id>shared-aws-s3</unique-id>
        <region>${amazon.region}</region>
        <credentials class="aws-static-credentials-builder">
          <authentication class="aws-keys-authentication">
            <access-key>${amazon.access.key}</access-key>
            <secret-key>${amazon.secret.key}</secret-key>
          </authentication>
        </credentials>
      </amazon-s3-connection>
```
- Change the retry store implementation in the `retry-store-write-message` and `retry-via-jetty` implementations.
```xml
          <retry-store class="amazon-s3-retry-store">
            <connection class="shared-connection">
              <lookup-name>shared-aws-s3</lookup-name>
            </connection>
            <bucket>${amazon.s3.bucket}</bucket>
            <prefix>${amazon.s3.prefix}</prefix>
          </retry-store>
```

- This now gives you (if you make a message fail first of all)

```console
$ curl -XGET -si http://localhost:8080/api/failed/list
HTTP/1.1 200 OK
Content-Type: application/json
Transfer-Encoding: chunked

[{"size":11,"name":"060dbc35-affe-4a10-b504-520edd0e2843","lastModified":1604400580000}]
chanl3@lhrm32445 ~/work/dev/aws/interlok-aws-s3 (INTERLOK-3465-S3-RetryStore-Impl)
$ curl -XGET -si http://localhost:8080/api/failed/list

chanl3@lhrm32445 ~/work/dev/aws/interlok-aws-s3 (INTERLOK-3465-S3-RetryStore-Impl)
$ curl -XPOST -si http://localhost:8080/api/retry/060dbc35-affe-4a10-b504-520edd0e2843
HTTP/1.1 202 Accepted
Content-Type: text/plain
Transfer-Encoding: chunked


```
