### PR TITLE
INTERLOK-3525 add STS support for building credentials

### DIFF
--- a/interlok-aws-common/build.gradle
+++ b/interlok-aws-common/build.gradle
@@ -11,6 +11,11 @@ dependencies {
     exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
     exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
   }
+  compile ("com.amazonaws:aws-java-sdk-sts:$awsSDKVersion") {
+    exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
+    exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
+    exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
+  }
   compile ("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
   compile ("com.fasterxml.jackson.core:jackson-core:$jacksonVersion")
   compile ("com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion")

--- a/interlok-aws-common/build.gradle
+++ b/interlok-aws-common/build.gradle
@@ -22,7 +22,7 @@ dependencies {
   // It will probably march in lockstep, but since it's a different
   // group I will make it separate.
   compile ("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.0")
-  compile ("com.adaptris:interlok-apache-http:$interlokCoreVersion")
+  compile ("com.adaptris:interlok-apache-http:$interlokCoreVersion") { changing = true}
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {

--- a/interlok-aws-common/src/main/java/com/adaptris/aws/AWSConnection.java
+++ b/interlok-aws-common/src/main/java/com/adaptris/aws/AWSConnection.java
@@ -18,12 +18,10 @@ package com.adaptris.aws;
 
 import javax.validation.Valid;
 import org.apache.commons.lang3.ObjectUtils;
-import org.apache.commons.lang3.StringUtils;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.core.AdaptrisConnectionImp;
 import com.adaptris.util.KeyValuePairSet;
-import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.regions.DefaultAwsRegionProviderChain;
 import lombok.Getter;
 import lombok.Setter;
@@ -140,21 +138,7 @@ public abstract class AWSConnection extends AdaptrisConnectionImp
   @Override
   public EndpointBuilder endpointBuilder() {
     return getCustomEndpoint() != null && getCustomEndpoint().isConfigured() ? getCustomEndpoint()
-        : new RegionOnly();
+        : new RegionEndpoint(getRegion());
   }
 
-
-
-  protected class RegionOnly implements EndpointBuilder {
-
-    @Override
-    public <T extends AwsClientBuilder<?, ?>> T rebuild(T builder) {
-      if (StringUtils.isNotBlank(getRegion())) {
-        log.trace("Setting Region to {}", getRegion());
-        builder.setRegion(getRegion());
-      }
-      return builder;
-    }
-
-  }
 }

--- a/interlok-aws-common/src/main/java/com/adaptris/aws/AWSConnection.java
+++ b/interlok-aws-common/src/main/java/com/adaptris/aws/AWSConnection.java
@@ -28,7 +28,8 @@ import com.amazonaws.regions.DefaultAwsRegionProviderChain;
 import lombok.Getter;
 import lombok.Setter;
 
-public abstract class AWSConnection extends AdaptrisConnectionImp {
+public abstract class AWSConnection extends AdaptrisConnectionImp
+    implements AWSCredentialsProviderBuilder.BuilderConfig {
 
   /**
    * Set the region for the client.
@@ -98,10 +99,12 @@ public abstract class AWSConnection extends AdaptrisConnectionImp {
     return AWSCredentialsProviderBuilder.defaultIfNull(getCredentials());
   }
 
+  @Override
   public KeyValuePairSet clientConfiguration() {
     return ObjectUtils.defaultIfNull(getClientConfiguration(), new KeyValuePairSet());
   }
 
+  @Override
   public RetryPolicyFactory retryPolicy() {
     return ObjectUtils.defaultIfNull(getRetryPolicy(), new DefaultRetryPolicyFactory());
   }
@@ -134,7 +137,8 @@ public abstract class AWSConnection extends AdaptrisConnectionImp {
   /** Returns something that can configure a normal AWS builder with a custom endpoint or a region...
    *
    */
-  protected EndpointBuilder endpointBuilder(){
+  @Override
+  public EndpointBuilder endpointBuilder() {
     return getCustomEndpoint() != null && getCustomEndpoint().isConfigured() ? getCustomEndpoint()
         : new RegionOnly();
   }

--- a/interlok-aws-common/src/main/java/com/adaptris/aws/AWSCredentialsProviderBuilder.java
+++ b/interlok-aws-common/src/main/java/com/adaptris/aws/AWSCredentialsProviderBuilder.java
@@ -1,6 +1,7 @@
 package com.adaptris.aws;
 
 import org.apache.commons.lang3.ObjectUtils;
+import com.adaptris.util.KeyValuePairSet;
 import com.amazonaws.auth.AWSCredentialsProvider;
 
 @FunctionalInterface
@@ -8,8 +9,20 @@ public interface AWSCredentialsProviderBuilder {
 
   AWSCredentialsProvider build() throws Exception;
 
+  default AWSCredentialsProvider build(BuilderConfig conf) throws Exception {
+    return build();
+  }
+
   static AWSCredentialsProviderBuilder defaultIfNull(AWSCredentialsProviderBuilder builder) {
     return ObjectUtils.defaultIfNull(builder,
         new StaticCredentialsBuilder().withAuthentication(new DefaultAWSAuthentication()));
+  }
+
+  interface BuilderConfig {
+    KeyValuePairSet clientConfiguration();
+
+    EndpointBuilder endpointBuilder();
+
+    RetryPolicyFactory retryPolicy();
   }
 }

--- a/interlok-aws-common/src/main/java/com/adaptris/aws/RegionEndpoint.java
+++ b/interlok-aws-common/src/main/java/com/adaptris/aws/RegionEndpoint.java
@@ -1,0 +1,30 @@
+package com.adaptris.aws;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+public class RegionEndpoint implements EndpointBuilder {
+
+  private transient Logger log = LoggerFactory.getLogger(this.getClass());
+
+  @Getter(AccessLevel.PRIVATE)
+  private transient String region = null;
+
+  public RegionEndpoint(String r) {
+    region = r;
+  }
+
+  @Override
+  public <T extends AwsClientBuilder<?, ?>> T rebuild(T builder) {
+    if (StringUtils.isNotBlank(getRegion())) {
+      log.trace("Setting Region to {}", getRegion());
+      builder.setRegion(getRegion());
+    }
+    return builder;
+  }
+
+}

--- a/interlok-aws-common/src/main/java/com/adaptris/aws/STSAssumeroleCredentialsBuilder.java
+++ b/interlok-aws-common/src/main/java/com/adaptris/aws/STSAssumeroleCredentialsBuilder.java
@@ -36,15 +36,15 @@ import lombok.Setter;
  * Security Credentials</a>.
  * </p>
  *
- * @config aws-sts-credentials-builder
+ * @config aws-sts-assumerole-credentials-builder
  */
-@XStreamAlias("aws-sts-credentials-builder")
+@XStreamAlias("aws-sts-assumerole-credentials-builder")
 @ComponentProfile(summary = "Create a set of credentials via STS",
-    tag = "amazon,aws,sts", since = "3.12.0")
+    tag = "amazon,aws,sts,assumerole", since = "3.12.0")
 @DisplayOrder(order = {"roleArn", "roleSessionName", "roleExternalId", "roleDurationSeconds",
     "scopeDownPolicy", "credentials", "sessionTags", "transitiveTagKeys"})
 @NoArgsConstructor
-public class STSCredentialsBuilder implements AWSCredentialsProviderBuilder {
+public class STSAssumeroleCredentialsBuilder implements AWSCredentialsProviderBuilder {
 
   /**
    * The underlying credentials used to access STS.
@@ -178,22 +178,22 @@ public class STSCredentialsBuilder implements AWSCredentialsProviderBuilder {
         .collect(Collectors.toList());
   }
 
-  public STSCredentialsBuilder withCredentials(AWSCredentialsProviderBuilder a) {
+  public STSAssumeroleCredentialsBuilder withCredentials(AWSCredentialsProviderBuilder a) {
     setCredentials(a);
     return this;
   }
 
-  public STSCredentialsBuilder withRoleArn(String s) {
+  public STSAssumeroleCredentialsBuilder withRoleArn(String s) {
     setRoleArn(s);
     return this;
   }
 
-  public STSCredentialsBuilder withRoleSessionName(String s) {
+  public STSAssumeroleCredentialsBuilder withRoleSessionName(String s) {
     setRoleSessionName(s);
     return this;
   }
 
-  public STSCredentialsBuilder withRoleExternalId(String s) {
+  public STSAssumeroleCredentialsBuilder withRoleExternalId(String s) {
     setRoleExternalId(s);
     return this;
   }

--- a/interlok-aws-common/src/main/java/com/adaptris/aws/STSCredentialsBuilder.java
+++ b/interlok-aws-common/src/main/java/com/adaptris/aws/STSCredentialsBuilder.java
@@ -1,0 +1,199 @@
+package com.adaptris.aws;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import org.apache.commons.lang3.ObjectUtils;
+import com.adaptris.annotation.AdvancedConfig;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldDefault;
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.interlok.resolver.ExternalResolver;
+import com.adaptris.security.password.Password;
+import com.adaptris.util.KeyValuePairSet;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider.Builder;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
+import com.amazonaws.services.securitytoken.model.Tag;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.Setter;
+
+/**
+ * AWS credentials that makes use of AWS STS
+ * <p>
+ * AWS Security Token Service (STS) enables you to request temporary, limited-privilege credentials
+ * for AWS Identity and Access Management (IAM) users or for users that you authenticate (federated
+ * users). For more information about using this service, see
+ * <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html">Temporary
+ * Security Credentials</a>.
+ * </p>
+ *
+ * @config aws-sts-credentials-builder
+ */
+@XStreamAlias("aws-sts-credentials-builder")
+@ComponentProfile(summary = "Create a set of credentials via STS", since = "3.12.0")
+@DisplayOrder(order = {"roleArn", "roleSessionName", "roleExternalId", "roleDurationSeconds",
+    "scopeDownPolicy", "credentials", "sessionTags", "transitiveTagKeys"})
+@NoArgsConstructor
+public class STSCredentialsBuilder implements AWSCredentialsProviderBuilder {
+
+  /**
+   * The underlying credentials used to access STS.
+   *
+   */
+  @NotNull
+  @Valid
+  @InputFieldDefault(value = "aws-static-credentials-builder with default credentials")
+  @Getter
+  @Setter
+  private AWSCredentialsProviderBuilder credentials;
+
+  /**
+   * The required roleArn parameter when starting a session.
+   *
+   */
+  @NonNull
+  @NotNull
+  @Getter
+  @Setter
+  private String roleArn;
+  /**
+   * The required roleSessionName when starting a session.
+   *
+   */
+  @NonNull
+  @NotNull
+  @Getter
+  @Setter
+  private String roleSessionName;
+  /**
+   * An external id used in the service call used to retrieve session credentials
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(style = "PASSWORD", external = true)
+  private String roleExternalId;
+
+  /**
+   * The transitive tag keys we want to pass to the assume role request
+   * <p>
+   * This defaults to {@code null} to avoid configuration clutter
+   * </p>
+   */
+  @Getter
+  @Setter
+  @AdvancedConfig
+  private List<String> transitiveTagKeys;
+  /**
+   * The collection of tags which we want to pass to the assume role request
+   * <p>
+   * This defaults to {@code null} to avoid configuration clutter
+   * </p>
+   */
+  @Getter
+  @Setter
+  @AdvancedConfig
+  private KeyValuePairSet sessionTags;
+  /**
+   * The duration for which we want to have an assumed role session to be active
+   * <p>
+   * This defaults to {@code null} to avoid configuration clutter
+   * </p>
+   */
+  @Getter
+  @Setter
+  @AdvancedConfig
+  private Integer roleDurationSeconds;
+  /**
+   * An IAM policy in JSON format to scope down permissions granted from the assume role.
+   * <p>
+   * This is passed though to
+   * {@code STSAssumeRoleSessionCredentialsProvider.Builder#withScopeDownPolicy(String)} as-is with
+   * no checking, is completely optional and defaults to {@code null} to avoid configuration clutter
+   * </p>
+   */
+  @Getter
+  @Setter
+  @AdvancedConfig(rare = true)
+  @InputFieldHint(style = "JSON")
+  private String scopeDownPolicy;
+
+  @Override
+  public AWSCredentialsProvider build() throws Exception {
+    return build(null);
+  }
+
+  @Override
+  public AWSCredentialsProvider build(BuilderConfig conf) throws Exception {
+    return configure(new Builder(getRoleArn(), getRoleSessionName()), securityToken(conf)).build();
+  }
+
+  private AWSSecurityTokenService securityToken(BuilderConfig conf) throws Exception {
+    AWSCredentialsProviderBuilder longlived =
+        AWSCredentialsProviderBuilder.defaultIfNull(getCredentials());
+    AWSSecurityTokenServiceClientBuilder stsBuilder =
+        AWSSecurityTokenServiceClientBuilder.standard();
+
+    // additional builder setters from the API that we're not exposing.
+    // stsBuilder.setClientSideMonitoringConfigurationProvider(csmConfig);
+    // stsBuilder.setMetricsCollector(metrics);
+    // stsBuilder.setMonitoringListener(monitoringListener);
+
+    if (conf != null) {
+      stsBuilder.setClientConfiguration(
+          ClientConfigurationBuilder.build(conf.clientConfiguration(), conf.retryPolicy()));
+      // CustomEndpoint has a EndpointConfiguration
+      // Connection#setRegion gives us a RegionOnly endpoint which gives us the correct
+      // EndpointConfiguration as well.
+      //
+      conf.endpointBuilder().rebuild(stsBuilder);
+      stsBuilder.setCredentials(longlived.build(conf));
+    } else {
+      stsBuilder.setCredentials(longlived.build());
+    }
+    return stsBuilder.build();
+  }
+
+  private Builder configure(Builder builder, AWSSecurityTokenService sts) throws Exception {
+    Optional.ofNullable(getRoleDurationSeconds()).ifPresent((seconds) -> builder.withRoleSessionDurationSeconds(seconds.intValue()));
+    Optional.ofNullable(getScopeDownPolicy()).ifPresent((policy) -> builder.withScopeDownPolicy(policy));
+    Optional.ofNullable(getTransitiveTagKeys()).ifPresent((keys) -> builder.withTransitiveTagKeys(keys));
+    return builder.withSessionTags(sessionTags()).withStsClient(sts)
+        .withExternalId(Password.decode(ExternalResolver.resolve(getRoleExternalId())));
+  }
+
+  private Collection<Tag> sessionTags() {
+    KeyValuePairSet tags = ObjectUtils.defaultIfNull(getSessionTags(), new KeyValuePairSet());
+    return tags.stream()
+        .map((kvp) -> new Tag().withKey(kvp.getKey()).withValue(kvp.getValue()))
+        .collect(Collectors.toList());
+  }
+
+  public STSCredentialsBuilder withCredentials(AWSCredentialsProviderBuilder a) {
+    setCredentials(a);
+    return this;
+  }
+
+  public STSCredentialsBuilder withRoleArn(String s) {
+    setRoleArn(s);
+    return this;
+  }
+
+  public STSCredentialsBuilder withRoleSessionName(String s) {
+    setRoleSessionName(s);
+    return this;
+  }
+
+  public STSCredentialsBuilder withRoleExternalId(String s) {
+    setRoleExternalId(s);
+    return this;
+  }
+}

--- a/interlok-aws-common/src/main/java/com/adaptris/aws/STSCredentialsBuilder.java
+++ b/interlok-aws-common/src/main/java/com/adaptris/aws/STSCredentialsBuilder.java
@@ -39,7 +39,8 @@ import lombok.Setter;
  * @config aws-sts-credentials-builder
  */
 @XStreamAlias("aws-sts-credentials-builder")
-@ComponentProfile(summary = "Create a set of credentials via STS", since = "3.12.0")
+@ComponentProfile(summary = "Create a set of credentials via STS",
+    tag = "amazon,aws,sts", since = "3.12.0")
 @DisplayOrder(order = {"roleArn", "roleSessionName", "roleExternalId", "roleDurationSeconds",
     "scopeDownPolicy", "credentials", "sessionTags", "transitiveTagKeys"})
 @NoArgsConstructor
@@ -151,7 +152,7 @@ public class STSCredentialsBuilder implements AWSCredentialsProviderBuilder {
       stsBuilder.setClientConfiguration(
           ClientConfigurationBuilder.build(conf.clientConfiguration(), conf.retryPolicy()));
       // CustomEndpoint has a EndpointConfiguration
-      // Connection#setRegion gives us a RegionOnly endpoint which gives us the correct
+      // Connection#setRegion gives us a RegionEndpoint which gives us the correct
       // EndpointConfiguration as well.
       //
       conf.endpointBuilder().rebuild(stsBuilder);

--- a/interlok-aws-common/src/main/java/com/adaptris/aws/apache/interceptor/ApacheSigningInterceptor.java
+++ b/interlok-aws-common/src/main/java/com/adaptris/aws/apache/interceptor/ApacheSigningInterceptor.java
@@ -2,19 +2,15 @@ package com.adaptris.aws.apache.interceptor;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.http.HttpRequestInterceptor;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.aws.AWSCredentialsProviderBuilder;
-import com.adaptris.aws.DefaultAWSAuthentication;
-import com.adaptris.aws.StaticCredentialsBuilder;
 import com.adaptris.core.http.apache.request.RequestInterceptorBuilder;
 import com.adaptris.interlok.util.Args;
 import com.amazonaws.auth.AWS4Signer;
-import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.http.AWSRequestSigningApacheInterceptor;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
@@ -26,14 +22,14 @@ import lombok.SneakyThrows;
 /**
  * {@code RequestInterceptorBuilder} implementation that creates an interceptor to sign requests
  * made to AWS using AWS4Signer
- * 
+ *
  * <p>
  * Note that this uses the interceptor from
  * <a href="https://github.com/awslabs/aws-request-signing-apache-interceptor/">this github
  * project</a> verbatim. It is in fact copied locally into a {@code com.amazonaws.http} package
  * since it is not officially published in any publicly available artifact.
  * </p>
- * 
+ *
  * @config aws-apache-signing-interceptor
  */
 @XStreamAlias("aws-apache-signing-interceptor")
@@ -96,8 +92,7 @@ public class ApacheSigningInterceptor implements RequestInterceptorBuilder {
   }
 
   private AWSCredentialsProviderBuilder credentialsProvider() {
-    return ObjectUtils.defaultIfNull(getCredentials(),
-        new StaticCredentialsBuilder().withAuthentication(new DefaultAWSAuthentication()));
+    return AWSCredentialsProviderBuilder.defaultIfNull(getCredentials());
   }
 
   public ApacheSigningInterceptor withRegion(String region) {

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/AwsConnectionTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/AwsConnectionTest.java
@@ -28,7 +28,7 @@ public class AwsConnectionTest extends AWSConnection {
     assertNotNull(credentialsProvider());
     assertEquals(StaticCredentialsBuilder.class, credentialsProvider().getClass());
     assertNull(getCredentials());
-    assertEquals(StaticCredentialsBuilder.class, credentialsProvider().getClass());    
+    assertEquals(StaticCredentialsBuilder.class, credentialsProvider().getClass());
     withCredentialsProviderBuilder(new StaticCredentialsBuilder().withAuthentication(new DefaultAWSAuthentication()));
     assertEquals(StaticCredentialsBuilder.class, credentialsProvider().getClass());
     assertEquals(DefaultAWSAuthentication.class, ((StaticCredentialsBuilder) credentialsProvider()).getAuthentication().getClass());
@@ -52,7 +52,7 @@ public class AwsConnectionTest extends AWSConnection {
     assertEquals(DefaultRetryPolicyFactory.class, retryPolicy().getClass());
     withRetryPolicy(new RetryNotFoundPolicyFactory());
     assertNotNull(getRetryPolicy());
-    assertEquals(RetryNotFoundPolicyFactory.class, retryPolicy().getClass());    
+    assertEquals(RetryNotFoundPolicyFactory.class, retryPolicy().getClass());
   }
 
   @Test
@@ -60,12 +60,12 @@ public class AwsConnectionTest extends AWSConnection {
     assertNull(getCustomEndpoint());
     setRegion("us-west-1");
     assertNotNull(endpointBuilder());
-    assertEquals(RegionOnly.class, endpointBuilder().getClass());
+    assertEquals(RegionEndpoint.class, endpointBuilder().getClass());
     withCustomEndpoint(new CustomEndpoint().withServiceEndpoint("http://localhost").withSigningRegion("us-west-1"));
     assertNotNull(getCustomEndpoint());
     assertEquals(CustomEndpoint.class, endpointBuilder().getClass());
   }
-  
+
 
   @Test
   public void testRegion() {
@@ -73,25 +73,25 @@ public class AwsConnectionTest extends AWSConnection {
     withRegion("us-west-1");
     assertEquals("us-west-1", getRegion());
     assertNotNull(endpointBuilder());
-    assertEquals(RegionOnly.class, endpointBuilder().getClass());
+    assertEquals(RegionEndpoint.class, endpointBuilder().getClass());
   }
-  
+
   @Test
   public void testRegionOnlyEndpointBuilder() {
     assertNull(getRegion());
     EndpointBuilder b0 = endpointBuilder();
-    assertEquals(RegionOnly.class, b0.getClass());
+    assertEquals(RegionEndpoint.class, b0.getClass());
     assertNull(b0.rebuild((AwsClientBuilder) new MockAwsClientBuilder()).getRegion());
 
     setRegion("us-west-1");
     assertEquals("us-west-1", getRegion());
     EndpointBuilder b1 = endpointBuilder();
-    assertEquals(RegionOnly.class, b1.getClass());
+    assertEquals(RegionEndpoint.class, b1.getClass());
     assertEquals("us-west-1", b1.rebuild((AwsClientBuilder)new MockAwsClientBuilder()).getRegion());
 
     setCustomEndpoint(new CustomEndpoint());
     EndpointBuilder b2 = endpointBuilder();
-    assertEquals(RegionOnly.class, b2.getClass());
+    assertEquals(RegionEndpoint.class, b2.getClass());
     assertEquals("us-west-1", b2.rebuild((AwsClientBuilder)new MockAwsClientBuilder()).getRegion());
 
     setCustomEndpoint(

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/STSCredentialsBuilderTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/STSCredentialsBuilderTest.java
@@ -1,0 +1,90 @@
+/*
+    Copyright 2018 Adaptris
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package com.adaptris.aws;
+
+import static org.junit.Assert.assertNotNull;
+import java.util.Arrays;
+import org.junit.Test;
+import com.adaptris.util.KeyValuePair;
+import com.adaptris.util.KeyValuePairSet;
+import com.amazonaws.SDKGlobalConfiguration;
+import com.amazonaws.auth.AWSCredentialsProvider;
+
+public class STSCredentialsBuilderTest {
+
+  @Test
+  public void testBuild() throws Exception {
+
+    STSCredentialsBuilder builder =
+        new STSCredentialsBuilder().withRoleArn("arn:aws:sts:us-west-1:123456789012:MyArn")
+            .withRoleExternalId("externalId").withRoleSessionName("sessionName")
+            .withCredentials(
+                new StaticCredentialsBuilder()
+                    .withAuthentication(new AWSKeysAuthentication("accessKey", "secretKey")));
+    builder.setScopeDownPolicy("{}");
+    builder.setRoleDurationSeconds(10);
+    builder.setTransitiveTagKeys(Arrays.asList("transitive1", "transitive2", "tt3"));
+    KeyValuePairSet sessionTags = new KeyValuePairSet();
+    sessionTags.add(new KeyValuePair("tag1", "value1"));
+    sessionTags.add(new KeyValuePair("tag2", "value2"));
+    builder.setSessionTags(sessionTags);
+
+    // Since we're using build() w/o additional cfg, we need to spoof
+    // DefaultAwsRegionProviderChain.
+    boolean needsClearing = false;
+    if (System.getProperty(SDKGlobalConfiguration.AWS_REGION_SYSTEM_PROPERTY) == null) {
+      System.setProperty(SDKGlobalConfiguration.AWS_REGION_SYSTEM_PROPERTY, "us-west-1");
+      needsClearing=true;
+    }
+    AWSCredentialsProvider credentials = builder.build();
+    if (needsClearing) {
+      System.clearProperty(SDKGlobalConfiguration.AWS_REGION_SYSTEM_PROPERTY);
+    }
+    assertNotNull(credentials);
+  }
+
+
+  @Test
+  public void testBuild_WithConfig() throws Exception {
+    STSCredentialsBuilder builder =
+        new STSCredentialsBuilder().withRoleArn("arn:aws:sts:us-west-1:123456789012:MyArn")
+        .withRoleExternalId("externalId").withRoleSessionName("sessionName");
+    AWSCredentialsProvider credentials = builder.build(new DummyConfig());
+    assertNotNull(credentials);
+  }
+
+
+  private class DummyConfig implements AWSCredentialsProviderBuilder.BuilderConfig {
+
+    @Override
+    public KeyValuePairSet clientConfiguration() {
+      return new KeyValuePairSet();
+    }
+
+    @Override
+    public EndpointBuilder endpointBuilder() {
+      return new CustomEndpoint().withServiceEndpoint("https://sts.us-west-1.amazonaws.com")
+          .withSigningRegion("us-west-1");
+    }
+
+    @Override
+    public RetryPolicyFactory retryPolicy() {
+      return new DefaultRetryPolicyFactory();
+    }
+
+  }
+}

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/STSCredentialsBuilderTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/STSCredentialsBuilderTest.java
@@ -29,8 +29,8 @@ public class STSCredentialsBuilderTest {
   @Test
   public void testBuild() throws Exception {
 
-    STSCredentialsBuilder builder =
-        new STSCredentialsBuilder().withRoleArn("arn:aws:sts:us-west-1:123456789012:MyArn")
+    STSAssumeroleCredentialsBuilder builder =
+        new STSAssumeroleCredentialsBuilder().withRoleArn("arn:aws:sts:us-west-1:123456789012:MyArn")
             .withRoleExternalId("externalId").withRoleSessionName("sessionName")
             .withCredentials(
                 new StaticCredentialsBuilder()
@@ -60,8 +60,8 @@ public class STSCredentialsBuilderTest {
 
   @Test
   public void testBuild_WithConfig() throws Exception {
-    STSCredentialsBuilder builder =
-        new STSCredentialsBuilder().withRoleArn("arn:aws:sts:us-west-1:123456789012:MyArn")
+    STSAssumeroleCredentialsBuilder builder =
+        new STSAssumeroleCredentialsBuilder().withRoleArn("arn:aws:sts:us-west-1:123456789012:MyArn")
         .withRoleExternalId("externalId").withRoleSessionName("sessionName");
     AWSCredentialsProvider credentials = builder.build(new DummyConfig());
     assertNotNull(credentials);

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/apache/interceptor/SigningnterceptorBuilderTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/apache/interceptor/SigningnterceptorBuilderTest.java
@@ -5,8 +5,8 @@ import static org.junit.Assert.assertNotNull;
 import org.apache.http.HttpRequestInterceptor;
 import org.junit.Test;
 import com.adaptris.aws.AWSCredentialsProviderBuilder;
+import com.adaptris.aws.STSCredentialsBuilder;
 import com.adaptris.aws.StaticCredentialsBuilder;
-import com.adaptris.aws.apache.interceptor.ApacheSigningInterceptor;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.http.AWSRequestSigningApacheInterceptor;
 
@@ -20,7 +20,7 @@ public class SigningnterceptorBuilderTest {
     HttpRequestInterceptor interceptor = builder.build();
     assertNotNull(interceptor);
     assertEquals(AWSRequestSigningApacheInterceptor.class, interceptor.getClass());
-    
+
   }
 
   @Test(expected=Exception.class)
@@ -28,7 +28,20 @@ public class SigningnterceptorBuilderTest {
     ApacheSigningInterceptor builder =
         new ApacheSigningInterceptor().withRegion("region").withService("service")
             .withCredentials(new FailingCredentialsBuilder());
-    HttpRequestInterceptor interceptor = builder.build();   
+    HttpRequestInterceptor interceptor = builder.build();
+  }
+
+  @Test
+  public void testBuild_WithSTS() {
+    STSCredentialsBuilder sts =
+        new STSCredentialsBuilder().withRoleArn("arn:aws:sts:us-west-1:123456789012:MyArn")
+            .withRoleExternalId("externalId").withRoleSessionName("sessionName");
+    ApacheSigningInterceptor builder = new ApacheSigningInterceptor().withRegion("region")
+        .withService("service").withCredentials(sts);
+    HttpRequestInterceptor interceptor = builder.build();
+    assertNotNull(interceptor);
+    assertEquals(AWSRequestSigningApacheInterceptor.class, interceptor.getClass());
+
   }
 
   private class FailingCredentialsBuilder implements AWSCredentialsProviderBuilder {
@@ -37,6 +50,6 @@ public class SigningnterceptorBuilderTest {
     public AWSCredentialsProvider build() throws Exception {
       throw new Exception();
     }
-    
+
   }
 }

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/apache/interceptor/SigningnterceptorBuilderTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/apache/interceptor/SigningnterceptorBuilderTest.java
@@ -5,7 +5,7 @@ import static org.junit.Assert.assertNotNull;
 import org.apache.http.HttpRequestInterceptor;
 import org.junit.Test;
 import com.adaptris.aws.AWSCredentialsProviderBuilder;
-import com.adaptris.aws.STSCredentialsBuilder;
+import com.adaptris.aws.STSAssumeroleCredentialsBuilder;
 import com.adaptris.aws.StaticCredentialsBuilder;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.http.AWSRequestSigningApacheInterceptor;
@@ -33,8 +33,8 @@ public class SigningnterceptorBuilderTest {
 
   @Test
   public void testBuild_WithSTS() {
-    STSCredentialsBuilder sts =
-        new STSCredentialsBuilder().withRoleArn("arn:aws:sts:us-west-1:123456789012:MyArn")
+    STSAssumeroleCredentialsBuilder sts =
+        new STSAssumeroleCredentialsBuilder().withRoleArn("arn:aws:sts:us-west-1:123456789012:MyArn")
             .withRoleExternalId("externalId").withRoleSessionName("sessionName");
     ApacheSigningInterceptor builder = new ApacheSigningInterceptor().withRegion("region")
         .withService("service").withCredentials(sts);

--- a/interlok-aws-kinesis/build.gradle
+++ b/interlok-aws-kinesis/build.gradle
@@ -6,8 +6,6 @@ ext {
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
   awsSDKVersion = '1.11.930'
 }
-
-// In this section you declare the dependencies for your production and test code
 dependencies {
   compile ("com.amazonaws:aws-java-sdk-kinesis:$awsSDKVersion")
   compile ("com.amazonaws:amazon-kinesis-client:1.13.3") {

--- a/interlok-aws-kms/build.gradle
+++ b/interlok-aws-kms/build.gradle
@@ -9,7 +9,11 @@ ext {
 
 dependencies {
   compile project(':interlok-aws-common')
-  compile ("com.amazonaws:aws-java-sdk-kms:$awsSDKVersion")
+  compile ("com.amazonaws:aws-java-sdk-kms:$awsSDKVersion") {
+    exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
+    exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
+    exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
+  }
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {

--- a/interlok-aws-kms/src/main/java/com/adaptris/aws/kms/AWSKMSConnection.java
+++ b/interlok-aws-kms/src/main/java/com/adaptris/aws/kms/AWSKMSConnection.java
@@ -32,7 +32,7 @@ import lombok.NoArgsConstructor;
 
 /**
  * {@linkplain AdaptrisConnection} implementation for Amazon KMS
- * 
+ *
  * <p>
  * This class directly exposes almost all the getter and setters that are available in {@link ClientConfiguration} via the
  * {@link #getClientConfiguration()} property for maximum flexibility in configuration.
@@ -41,9 +41,9 @@ import lombok.NoArgsConstructor;
  * The key from the <code>client-configuration</code> element should match the name of the underlying ClientConfiguration property;
  * so if you wanted to control the user-agent you would do :
  * </p>
- * 
+ *
  * <pre>
- * {@code 
+ * {@code
  *   <client-configuration>
  *     <key-value-pair>
  *        <key>UserAgent</key>
@@ -52,8 +52,8 @@ import lombok.NoArgsConstructor;
  *   </client-configuration>
  * }
  * </pre>
- * 
- * 
+ *
+ *
  * @config aws-kms-connection
  */
 @XStreamAlias("aws-kms-connection")
@@ -100,7 +100,7 @@ public class AWSKMSConnection extends AWSConnection implements ClientWrapper<AWS
       ClientConfiguration cc =
           ClientConfigurationBuilder.build(clientConfiguration(), retryPolicy());
       builder = endpointBuilder().rebuild(AWSKMSClientBuilder.standard().withClientConfiguration(cc));
-      builder.withCredentials(credentialsProvider().build());
+      builder.withCredentials(credentialsProvider().build(this));
     } catch (Exception e) {
       throw ExceptionHelper.wrapCoreException(e);
     }

--- a/interlok-aws-s3/build.gradle
+++ b/interlok-aws-s3/build.gradle
@@ -7,9 +7,12 @@ ext {
   awsSDKVersion = '1.11.930'
 }
 
-// In this section you declare the dependencies for your production and test code
 dependencies {
-  compile ("com.amazonaws:aws-java-sdk-s3:$awsSDKVersion")
+  compile ("com.amazonaws:aws-java-sdk-s3:$awsSDKVersion") {
+    exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
+    exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
+    exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
+  }
   compile project(':interlok-aws-common')
 }
 

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/AmazonS3Connection.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/AmazonS3Connection.java
@@ -37,7 +37,7 @@ import lombok.Setter;
 
 /**
  * {@linkplain AdaptrisConnection} implementation for Amazon S3.
- * 
+ *
  * <p>
  * This class directly exposes almost all the getter and setters that are available in {@link ClientConfiguration} via the
  * {@link #getClientConfiguration()} property for maximum flexibility in configuration.
@@ -47,7 +47,7 @@ import lombok.Setter;
  * so if you wanted to control the user-agent you would do :
  * </p>
  * <pre>
- * {@code 
+ * {@code
  *   <client-configuration>
  *     <key-value-pair>
  *        <key>UserAgent</key>
@@ -56,8 +56,8 @@ import lombok.Setter;
  *   </client-configuration>
  * }
  * </pre>
- * 
- * 
+ *
+ *
  * @config amazon-s3-connection
  */
 @XStreamAlias("amazon-s3-connection")
@@ -108,7 +108,7 @@ public class AmazonS3Connection extends AWSConnection implements ClientWrapper {
       if (getForcePathStyleAccess() != null) {
         builder.setPathStyleAccessEnabled(getForcePathStyleAccess());
       }
-      builder.withCredentials(credentialsProvider().build());
+      builder.withCredentials(credentialsProvider().build(this));
     } catch (Exception e) {
       throw ExceptionHelper.wrapCoreException(e);
     }

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/LocalstackConfig.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/LocalstackConfig.java
@@ -22,6 +22,8 @@ public class LocalstackConfig {
   public static final String S3_RETRY_PREFIX = "localstack.s3.retry.prefix";
   public static final String S3_RETRY_BUCKET_NAME = "localstack.s3.retry.bucketname";
 
+  public static final String EXTENDED_COPY_ENABLED = "localstack.s3.extended.copy.tests";
+
   public static final String PROPERTIES_RESOURCE = "unit-tests.properties";
 
   private static Properties config = PropertyHelper.loadQuietly(PROPERTIES_RESOURCE);
@@ -36,6 +38,10 @@ public class LocalstackConfig {
 
   public static boolean areTestsEnabled() {
     return BooleanUtils.toBoolean(getConfiguration().getProperty(TESTS_ENABLED, "false"));
+  }
+
+  public static boolean extendedCopyTests() {
+    return BooleanUtils.toBoolean(getConfiguration().getProperty(EXTENDED_COPY_ENABLED, "false"));
   }
 
   public static S3Service build(S3Operation operation) {

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/LocalstackServiceTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/LocalstackServiceTest.java
@@ -8,6 +8,7 @@ import static com.adaptris.aws.s3.LocalstackConfig.S3_FILTER_REGEXP;
 import static com.adaptris.aws.s3.LocalstackConfig.S3_UPLOAD_FILENAME;
 import static com.adaptris.aws.s3.LocalstackConfig.areTestsEnabled;
 import static com.adaptris.aws.s3.LocalstackConfig.build;
+import static com.adaptris.aws.s3.LocalstackConfig.extendedCopyTests;
 import static com.adaptris.aws.s3.LocalstackConfig.getConfiguration;
 import static com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase.execute;
 import static org.junit.Assert.assertEquals;
@@ -139,6 +140,8 @@ public class LocalstackServiceTest {
 
   @Test
   public void test_10_ExtendedCopy_WithoutDestinationBucket() throws Exception {
+    // INTERLOK-3544 localstack is broken for the test.
+    Assume.assumeTrue(extendedCopyTests());
     tagObject(getConfig(S3_UPLOAD_FILENAME));
 
     ExtendedCopyOperation copy = new ExtendedCopyOperation()
@@ -164,6 +167,8 @@ public class LocalstackServiceTest {
 
   @Test
   public void test_11_DeleteCopy() throws Exception {
+    // INTERLOK-3544 localstack is broken for the test.
+    Assume.assumeTrue(extendedCopyTests());
     DeleteOperation delete =
         new DeleteOperation().withObjectName(getConfig(S3_COPY_TO_FILENAME))
             .withBucket(getConfig(S3_BUCKETNAME));
@@ -233,5 +238,4 @@ public class LocalstackServiceTest {
     execute(retrieveTags, msgWithTags);
     return msgWithTags;
   }
-
 }

--- a/interlok-aws-sns/build.gradle
+++ b/interlok-aws-sns/build.gradle
@@ -4,13 +4,11 @@ ext {
   awsSDKVersion = '1.11.930'
 }
 
-// In this section you declare the dependencies for your production and test code
 dependencies {
   compile ("com.amazonaws:aws-java-sdk-sns:$awsSDKVersion") {
     exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
-  }
-  compile ("com.amazonaws:aws-java-sdk-core:$awsSDKVersion") {
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
+    exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
+    exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
   }
   compile project(':interlok-aws-common')
 }

--- a/interlok-aws-sns/src/main/java/com/adaptris/aws/sns/AmazonSNSConnection.java
+++ b/interlok-aws-sns/src/main/java/com/adaptris/aws/sns/AmazonSNSConnection.java
@@ -31,7 +31,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * {@linkplain AdaptrisConnection} implementation for Amazon SNS.
- * 
+ *
  * <p>
  * This class directly exposes almost all the getter and setters that are available in {@link ClientConfiguration} via the
  * {@link #getClientConfiguration()} property for maximum flexibility in configuration.
@@ -41,7 +41,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * so if you wanted to control the user-agent you would do :
  * </p>
  * <pre>
- * {@code 
+ * {@code
  *   <client-configuration>
  *     <key-value-pair>
  *        <key>UserAgent</key>
@@ -50,8 +50,8 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  *   </client-configuration>
  * }
  * </pre>
- * 
- * 
+ *
+ *
  * @config amazon-sns-connection
  */
 @XStreamAlias("amazon-sns-connection")
@@ -76,7 +76,7 @@ public class AmazonSNSConnection extends AWSConnection {
     try {
       ClientConfiguration cc = ClientConfigurationBuilder.build(clientConfiguration(), retryPolicy());
       AmazonSNSClientBuilder builder = endpointBuilder().rebuild(AmazonSNSClientBuilder.standard().withClientConfiguration(cc));
-      builder.withCredentials(credentialsProvider().build());
+      builder.withCredentials(credentialsProvider().build(this));
       snsClient = (AmazonSNSClient) builder.build();
     }
     catch (Exception e) {
@@ -102,7 +102,7 @@ public class AmazonSNSConnection extends AWSConnection {
   public AmazonSNSClient amazonClient() {
     return snsClient;
   }
-  
+
   protected static void closeQuietly(AmazonSNSClient c) {
     if (c != null) {
       c.shutdown();

--- a/interlok-aws-sqs/build.gradle
+++ b/interlok-aws-sqs/build.gradle
@@ -4,11 +4,7 @@ ext {
   awsSDKVersion = '1.11.930'
 }
 
-// In this section you declare the dependencies for your production and test code
 dependencies {
-  compile ("com.amazonaws:aws-java-sdk-core:$awsSDKVersion") {
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
-  }
   compile ("com.amazonaws:aws-java-sdk-sqs:$awsSDKVersion")
   compile ("com.amazonaws:amazon-sqs-java-messaging-lib:1.0.8")
   compile ("com.fasterxml.jackson.core:jackson-databind:2.12.0")

--- a/interlok-aws-sqs/src/main/java/com/adaptris/aws/sqs/AmazonSQSConnection.java
+++ b/interlok-aws-sqs/src/main/java/com/adaptris/aws/sqs/AmazonSQSConnection.java
@@ -39,7 +39,7 @@ import lombok.Setter;
 
 /**
  * {@linkplain AdaptrisConnection} implementation for Amazon SQS.
- * 
+ *
  * <p>
  * This class directly exposes almost all the getter and setters that are available in {@link ClientConfiguration} via the
  * {@link #getClientConfiguration()} property for maximum flexibility in configuration.
@@ -49,7 +49,7 @@ import lombok.Setter;
  * property; so if you wanted to control the user-agent you would do :
  * </p>
  * <pre>
- * {@code 
+ * {@code
  *   <client-configuration>
  *     <key-value-pair>
  *        <key>UserAgent</key>
@@ -58,8 +58,8 @@ import lombok.Setter;
  *   </client-configuration>
  * }
  * </pre>
- * 
- * 
+ *
+ *
  * @config amazon-sqs-connection
  * @since 3.0.3
  */
@@ -108,7 +108,8 @@ public class AmazonSQSConnection extends AWSConnection {
   protected synchronized void initConnection() throws CoreException {
     try {
       ClientConfiguration cc = ClientConfigurationBuilder.build(clientConfiguration(), retryPolicy());
-      sqsClient = getSqsClientFactory().createClient(credentialsProvider().build(), cc, endpointBuilder());
+      sqsClient = getSqsClientFactory().createClient(credentialsProvider().build(this), cc,
+          endpointBuilder());
     } catch (Exception e) {
       throw ExceptionHelper.wrapCoreException(e);
     }
@@ -134,7 +135,7 @@ public class AmazonSQSConnection extends AWSConnection {
     if(sqsClient == null) {
       throw new CoreException("Amazon SQS Connection is not initialized");
     }
-    
+
     return sqsClient;
   }
 
@@ -145,7 +146,7 @@ public class AmazonSQSConnection extends AWSConnection {
     if(sqsClient == null) {
       throw new CoreException("Amazon SQS Connection is not initialized");
     }
-    
+
     return sqsClient;
   }
 }

--- a/interlok-aws-sqs/src/main/java/com/adaptris/aws/sqs/jms/AdvancedSQSImplementation.java
+++ b/interlok-aws-sqs/src/main/java/com/adaptris/aws/sqs/jms/AdvancedSQSImplementation.java
@@ -28,8 +28,6 @@ import com.adaptris.aws.DefaultRetryPolicyFactory;
 import com.adaptris.aws.EndpointBuilder;
 import com.adaptris.aws.RetryPolicyFactory;
 import com.adaptris.util.KeyValuePairSet;
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.retry.RetryPolicy;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import lombok.Getter;
 import lombok.NonNull;
@@ -107,13 +105,12 @@ public class AdvancedSQSImplementation extends AmazonSQSImplementation {
   }
 
   @Override
-  protected ClientConfiguration clientConfiguration() throws Exception {
-    return ClientConfigurationBuilder.build(getClientConfigurationProperties())
-        .withRetryPolicy(retryPolicy());
+  public KeyValuePairSet clientConfiguration() {
+    return ObjectUtils.defaultIfNull(getClientConfigurationProperties(), new KeyValuePairSet());
   }
 
   @Override
-  protected EndpointBuilder endpointBuilder(){
+  public EndpointBuilder endpointBuilder() {
     return getCustomEndpoint() != null && getCustomEndpoint().isConfigured() ? getCustomEndpoint()
         : new RegionOnly();
   }
@@ -123,8 +120,9 @@ public class AdvancedSQSImplementation extends AmazonSQSImplementation {
     return this;
   }
 
-  RetryPolicy retryPolicy() throws Exception {
-    return ObjectUtils.defaultIfNull(getRetryPolicy(), new DefaultRetryPolicyFactory()).build();
+  @Override
+  public RetryPolicyFactory retryPolicy() {
+    return ObjectUtils.defaultIfNull(getRetryPolicy(), new DefaultRetryPolicyFactory());
   }
 
 }

--- a/interlok-aws-sqs/src/main/java/com/adaptris/aws/sqs/jms/AdvancedSQSImplementation.java
+++ b/interlok-aws-sqs/src/main/java/com/adaptris/aws/sqs/jms/AdvancedSQSImplementation.java
@@ -26,6 +26,7 @@ import com.adaptris.aws.ClientConfigurationBuilder;
 import com.adaptris.aws.CustomEndpoint;
 import com.adaptris.aws.DefaultRetryPolicyFactory;
 import com.adaptris.aws.EndpointBuilder;
+import com.adaptris.aws.RegionEndpoint;
 import com.adaptris.aws.RetryPolicyFactory;
 import com.adaptris.util.KeyValuePairSet;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -112,7 +113,7 @@ public class AdvancedSQSImplementation extends AmazonSQSImplementation {
   @Override
   public EndpointBuilder endpointBuilder() {
     return getCustomEndpoint() != null && getCustomEndpoint().isConfigured() ? getCustomEndpoint()
-        : new RegionOnly();
+        : new RegionEndpoint(getRegion());
   }
 
   public AdvancedSQSImplementation withCustomEndpoint(CustomEndpoint endpoint) {

--- a/interlok-aws-sqs/src/main/java/com/adaptris/aws/sqs/jms/AmazonSQSImplementation.java
+++ b/interlok-aws-sqs/src/main/java/com/adaptris/aws/sqs/jms/AmazonSQSImplementation.java
@@ -20,7 +20,6 @@ import static com.adaptris.core.jms.JmsUtils.wrapJMSException;
 import javax.jms.JMSException;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import org.apache.commons.lang3.StringUtils;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.annotation.DisplayOrder;
@@ -29,6 +28,7 @@ import com.adaptris.aws.AWSCredentialsProviderBuilder;
 import com.adaptris.aws.ClientConfigurationBuilder;
 import com.adaptris.aws.DefaultRetryPolicyFactory;
 import com.adaptris.aws.EndpointBuilder;
+import com.adaptris.aws.RegionEndpoint;
 import com.adaptris.aws.RetryPolicyFactory;
 import com.adaptris.aws.sqs.SQSClientFactory;
 import com.adaptris.aws.sqs.UnbufferedSQSClientFactory;
@@ -39,7 +39,6 @@ import com.adaptris.util.NumberUtils;
 import com.amazon.sqs.javamessaging.ProviderConfiguration;
 import com.amazon.sqs.javamessaging.SQSConnectionFactory;
 import com.amazonaws.ClientConfiguration;
-import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.regions.DefaultAwsRegionProviderChain;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -172,7 +171,7 @@ public class AmazonSQSImplementation extends VendorImplementationImp
 
   @Override
   public EndpointBuilder endpointBuilder() {
-    return new RegionOnly();
+    return new RegionEndpoint(getRegion());
   }
 
   @Override
@@ -188,18 +187,5 @@ public class AmazonSQSImplementation extends VendorImplementationImp
 
   protected ProviderConfiguration newProviderConfiguration() {
     return new ProviderConfiguration().withNumberOfMessagesToPrefetch(prefetchCount());
-  }
-
-  protected class RegionOnly implements EndpointBuilder {
-
-    @Override
-    public <T extends AwsClientBuilder<?, ?>> T rebuild(T builder) {
-      if (StringUtils.isNotBlank(getRegion())) {
-        log.trace("Setting Region to {}", getRegion());
-        builder.setRegion(getRegion());
-      }
-      return builder;
-    }
-
   }
 }


### PR DESCRIPTION
## Motivation

We need assume an IAM role before accessing an S3 bucket. This is a way to establish a trust relationship between AWS accounts where customers can give us access to some of their resources (like S3 buckets) without having to pass any explicit credentials.

This can be achieved by using `STSAssumeRoleSessionCredentialsProvider` via the AWS Security Token Service (`com.amazonaws:aws-java-sdk-sts`)

## Modification

- Add a new method to the existing AwsCredentialsProviderBuilder interface that has additional configuration; the default delegates to the existing `build()` method.
- Add a STSCredentialsBuilder which ultimately creates a `STSAssumeRoleSessionCredentialsProvider` and wraps some long lived credentials
- Promoted the protected `RegionOnly` class from AWSConnection / JmsImpls into a public class in aws-common.
- Added support for STS credentials to ApacheSigningInterceptor

Also fixes INTERLOK-3544 by skipping the extended-copy tests by default if localstack is enabled. Recently localstack images don't behave in the same way as "real S3" which causes some issues with extended copy since the content-length is stored as S3ObjectMetadata in localstack.

## Result

- `aws-sts-credentials-builder` is now available to configure where a credentials provider builder is required.
- additional settings are available to configure on ApacheSigningInterceptor if required.

## Testing

- First setup secure token service in your AWS account
- Configure and use STS to access whatever resources you need to access.

