### PR TITLE
updated the ConfigDeprecated/Removal annotations; from 3.12 to 4

### DIFF
--- a/interlok-aws-common/src/main/java/com/adaptris/aws/STSAssumeroleCredentialsBuilder.java
+++ b/interlok-aws-common/src/main/java/com/adaptris/aws/STSAssumeroleCredentialsBuilder.java
@@ -40,7 +40,7 @@ import lombok.Setter;
  */
 @XStreamAlias("aws-sts-assumerole-credentials-builder")
 @ComponentProfile(summary = "Create a set of credentials via STS",
-    tag = "amazon,aws,sts,assumerole", since = "3.12.0")
+    tag = "amazon,aws,sts,assumerole", since = "4.0.0")
 @DisplayOrder(order = {"roleArn", "roleSessionName", "roleExternalId", "roleDurationSeconds",
     "scopeDownPolicy", "credentials", "sessionTags", "transitiveTagKeys"})
 @NoArgsConstructor

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/CopyOperation.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/CopyOperation.java
@@ -65,7 +65,7 @@ public class CopyOperation extends CopyOperationImpl {
   @Getter
   @Setter
   @Deprecated
-  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use an expression based bucket instead", groups = Deprecated.class)
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use an expression based bucket instead", groups = Deprecated.class)
   private DataInputParameter<String> destinationBucketName;
   /**
    * The destination object.
@@ -74,7 +74,7 @@ public class CopyOperation extends CopyOperationImpl {
   @Getter
   @Setter
   @Deprecated
-  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use an expression based key instead", groups = Deprecated.class)
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use an expression based key instead", groups = Deprecated.class)
   private DataInputParameter<String> destinationKey;
 
 

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3BucketList.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3BucketList.java
@@ -67,7 +67,7 @@ public class S3BucketList extends ServiceImp implements DynamicPollingTemplate.T
   @Setter
   @Getter
   @Deprecated
-  @ConfigDeprecated(removalVersion = "3.12.0", message = "use prefix instead", groups = Deprecated.class)
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "use prefix instead", groups = Deprecated.class)
   private String key;
 
   /**
@@ -152,7 +152,7 @@ public class S3BucketList extends ServiceImp implements DynamicPollingTemplate.T
 
 
   @Deprecated
-  @Removal(version = "3.12.0", message = "Use prefix instead")
+  @Removal(version = "4.0.0", message = "Use prefix instead")
   public S3BucketList withKey(String key) {
     setKey(key);
     return this;

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3OperationImpl.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/S3OperationImpl.java
@@ -48,14 +48,14 @@ public abstract class S3OperationImpl implements S3Operation {
   @Setter
   @Valid
   @Deprecated
-  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use an expression based bucket instead", groups = Deprecated.class)
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use an expression based bucket instead", groups = Deprecated.class)
   private DataInputParameter<String> bucketName;
   @AdvancedConfig(rare = true)
   @Getter
   @Setter
   @Valid
   @Deprecated
-  @ConfigDeprecated(removalVersion = "3.12.0", message = "Use an expression based blob-name/prefix instead", groups = Deprecated.class)
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "Use an expression based blob-name/prefix instead", groups = Deprecated.class)
   private DataInputParameter<String> key;
 
   @Getter

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ExpirationTimeRuleId.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/meta/S3ExpirationTimeRuleId.java
@@ -47,7 +47,7 @@ public class S3ExpirationTimeRuleId extends S3ObjectMetadata {
   @Getter
   @Setter
   @Deprecated
-  @ConfigDeprecated(removalVersion = "3.12.0", message = "naming mismatch, use 'expiration-time-rule-id' instead", groups = Deprecated.class)
+  @ConfigDeprecated(removalVersion = "4.0.0", message = "naming mismatch, use 'expiration-time-rule-id' instead", groups = Deprecated.class)
   private String expirationRuleId;
 
   /**


### PR DESCRIPTION
## Motivation

Config components are marked as being removed in 3.12.0 but these changes are now being delayed until 4.0.0

## Modification

updated the ConfigDeprecated/Removal annotations

## Result

any warnings generated from config checker / ui will be correct

## Testing

just eyeball the changes and make sure nothing stupid was done
