### PR TITLE
INTERLOK-3826 Add the ability to set custom object acls

### DIFF
--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/UploadOperation.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/UploadOperation.java
@@ -17,14 +17,18 @@
 package com.adaptris.aws.s3;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
 import javax.validation.Valid;
+
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
+
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
@@ -35,11 +39,11 @@ import com.adaptris.aws.s3.meta.S3ObjectMetadata;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.util.ManagedThreadFactory;
 import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.Owner;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.Upload;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -145,7 +149,7 @@ public class UploadOperation extends TransferOperation {
     public void run() {
       Thread.currentThread().setName(name);
       while (!upload.isDone()) {
-        log.trace("Uploaded : {}%", (upload.getProgress().getPercentTransferred() / 1));
+        log.trace("Uploaded : {}%", upload.getProgress().getPercentTransferred() / 1);
         try {
           Thread.sleep(2000);
         } catch (InterruptedException e) {

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/acl/S3ObjectAcl.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/acl/S3ObjectAcl.java
@@ -1,0 +1,42 @@
+package com.adaptris.aws.s3.acl;
+
+import java.util.List;
+
+import com.amazonaws.services.s3.model.AccessControlList;
+import com.amazonaws.services.s3.model.Owner;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamImplicit;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Represents an Amazon S3 Access Control List (ACL), including the ACL's set of
+ * grantees and the permissions assigned to each grantee.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@XStreamAlias("s3-object-acl")
+public class S3ObjectAcl {
+
+  @Getter
+  @Setter
+  @XStreamImplicit
+  private List<S3ObjectAclGrant> grants;
+
+  public AccessControlList create() {
+    AccessControlList objectAcl = new AccessControlList();
+
+
+    for (S3ObjectAclGrant grant : getGrants()){
+      if(grant.grant()){
+        objectAcl.grantAllPermissions(grant.create());
+      }
+    }
+
+    return objectAcl;
+  }
+
+}

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/acl/S3ObjectAcl.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/acl/S3ObjectAcl.java
@@ -2,8 +2,9 @@ package com.adaptris.aws.s3.acl;
 
 import java.util.List;
 
+import org.apache.commons.collections4.ListUtils;
+
 import com.amazonaws.services.s3.model.AccessControlList;
-import com.amazonaws.services.s3.model.Owner;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 
@@ -29,8 +30,7 @@ public class S3ObjectAcl {
   public AccessControlList create() {
     AccessControlList objectAcl = new AccessControlList();
 
-
-    for (S3ObjectAclGrant grant : getGrants()){
+    for (S3ObjectAclGrant grant : ListUtils.emptyIfNull(getGrants())) {
       if(grant.grant()){
         objectAcl.grantAllPermissions(grant.create());
       }

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/acl/S3ObjectAclGrant.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/acl/S3ObjectAclGrant.java
@@ -4,7 +4,6 @@ package com.adaptris.aws.s3.acl;
 import com.adaptris.annotation.DisplayOrder;
 import com.adaptris.annotation.InputFieldHint;
 import com.amazonaws.services.s3.model.Grant;
-import com.amazonaws.services.s3.model.Owner;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 import lombok.AllArgsConstructor;
@@ -30,6 +29,13 @@ public class S3ObjectAclGrant {
 
   /**
    * The permission being granted to the grantee by this grant.
+   * <ul>
+   * <li><b>FULL_CONTROL:</b> Allows grantee the READ, READ_ACP, and WRITE_ACP permissions on the object.</li>
+   * <li><b>READ:</b> Allows grantee to read the object data and its metadata.</li>
+   * <li><b>READ_ACP:</b> Allows grantee to read the object ACL.</li>
+   * <li><b>WRITE:</b> Not applicable for objects, only for buckets.</li>
+   * <li><b>WRITE_ACP:</b> Allows grantee to write the ACL for the applicable object.</li>
+   * </ul>
    */
   @Getter
   @Setter

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/acl/S3ObjectAclGrant.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/acl/S3ObjectAclGrant.java
@@ -1,0 +1,47 @@
+package com.adaptris.aws.s3.acl;
+
+
+import com.adaptris.annotation.DisplayOrder;
+import com.adaptris.annotation.InputFieldHint;
+import com.amazonaws.services.s3.model.Grant;
+import com.amazonaws.services.s3.model.Owner;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Specifies a grant, consisting of one grantee and one permission.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@XStreamAlias("s3-object-grant")
+@DisplayOrder(order = {"grantee", "permission"})
+public class S3ObjectAclGrant {
+
+  /**
+   * The grantee being granted a permission by this grant.
+   */
+  @Getter
+  @Setter
+  private S3ObjectAclGrantee grantee;
+
+  /**
+   * The permission being granted to the grantee by this grant.
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(style = "com.adaptris.aws.s3.S3ObjectAclPermission")
+  private S3ObjectAclPermission permission;
+
+  boolean grant(){
+    return getGrantee().grant();
+  }
+
+  Grant create() {
+    return new Grant(getGrantee().create(), getPermission().create());
+  }
+
+}

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/acl/S3ObjectAclGrantee.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/acl/S3ObjectAclGrantee.java
@@ -1,0 +1,12 @@
+package com.adaptris.aws.s3.acl;
+
+import com.amazonaws.services.s3.model.Grantee;
+import com.amazonaws.services.s3.model.Owner;
+
+public interface S3ObjectAclGrantee {
+
+  boolean grant();
+
+  Grantee create();
+
+}

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/acl/S3ObjectAclGrantee.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/acl/S3ObjectAclGrantee.java
@@ -1,7 +1,6 @@
 package com.adaptris.aws.s3.acl;
 
 import com.amazonaws.services.s3.model.Grantee;
-import com.amazonaws.services.s3.model.Owner;
 
 public interface S3ObjectAclGrantee {
 

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/acl/S3ObjectAclGranteeCanonicalUser.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/acl/S3ObjectAclGranteeCanonicalUser.java
@@ -1,0 +1,40 @@
+package com.adaptris.aws.s3.acl;
+
+import com.amazonaws.services.s3.model.CanonicalGrantee;
+import com.amazonaws.services.s3.model.Grantee;
+import com.amazonaws.services.s3.model.Owner;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import org.apache.commons.lang3.StringUtils;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Represents a grantee identified by their canonical Amazon ID.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@XStreamAlias("s3-object-acl-grantee-canonical-user")
+public class S3ObjectAclGranteeCanonicalUser implements S3ObjectAclGrantee {
+
+  /**
+   * Represents a grantee identified by their canonical Amazon ID.
+   */
+  @Getter
+  @Setter
+  private String id;
+
+  @Override
+  public boolean grant() {
+    return StringUtils.isNotEmpty(getId());
+  }
+
+  @Override
+  public Grantee create() {
+    return new CanonicalGrantee(getId());
+  }
+
+}

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/acl/S3ObjectAclGranteeCanonicalUser.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/acl/S3ObjectAclGranteeCanonicalUser.java
@@ -1,11 +1,10 @@
 package com.adaptris.aws.s3.acl;
 
+import org.apache.commons.lang3.StringUtils;
+
 import com.amazonaws.services.s3.model.CanonicalGrantee;
 import com.amazonaws.services.s3.model.Grantee;
-import com.amazonaws.services.s3.model.Owner;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-
-import org.apache.commons.lang3.StringUtils;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/acl/S3ObjectAclPermission.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/acl/S3ObjectAclPermission.java
@@ -1,0 +1,25 @@
+package com.adaptris.aws.s3.acl;
+
+import com.amazonaws.services.s3.model.Permission;
+
+import lombok.AllArgsConstructor;
+
+/**
+ * Specifies constants defining an access permission.
+ */
+@AllArgsConstructor
+public enum S3ObjectAclPermission {
+
+  FULL_CONTROL(Permission.FullControl),
+  READ(Permission.Read),
+  READ_ACP(Permission.ReadAcp),
+  WRITE(Permission.Write),
+  WRITE_ACP(Permission.WriteAcp);
+
+  private Permission permission;
+
+  Permission create(){
+    return permission;
+  }
+
+}

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/acl/S3ObjectAclTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/acl/S3ObjectAclTest.java
@@ -1,0 +1,36 @@
+package com.adaptris.aws.s3.acl;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.amazonaws.services.s3.model.AccessControlList;
+import com.amazonaws.services.s3.model.Grant;
+import com.amazonaws.services.s3.model.Permission;
+
+import org.junit.Test;
+
+public class S3ObjectAclTest {
+
+  @Test
+  public void create() throws Exception {
+
+    List<S3ObjectAclGrant> grants = Arrays.asList(
+      new S3ObjectAclGrant(new S3ObjectAclGranteeCanonicalUser("123"), S3ObjectAclPermission.READ),
+      new S3ObjectAclGrant(new S3ObjectAclGranteeCanonicalUser(), S3ObjectAclPermission.READ)
+    );
+
+    S3ObjectAcl objectAcl = new S3ObjectAcl(grants);
+
+    AccessControlList acl = objectAcl.create();
+
+    List<Grant> resultGrants = acl.getGrantsAsList();
+    assertEquals(1, resultGrants.size());
+
+    assertEquals("123", resultGrants.get(0).getGrantee().getIdentifier());
+    assertEquals(Permission.Read, resultGrants.get(0).getPermission());
+
+  }
+
+}


### PR DESCRIPTION
## Motivation

Allow for custom object ACLs to set during upload.

## Modification

Added new property on upload operation and corresponding config classes.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like XStreamAlias / ComponentProfile)
- [x] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI

## Result

User can configure an object acl which will then be applied upon upload.

## Testing

Using [interlok-aws-interop](https://github.com/adaptris-labs/interlok-aws-interop)

Update `upload-to-s3`, setting `account.id` you can get id using:

```shell
 aws s3api list-buckets --query Owner.ID --output text
```

```xml
<amazon-s3-service>
  <unique-id>upload-to-s3</unique-id>
  <connection class="shared-connection">
    <lookup-name>s3</lookup-name>
  </connection>
  <operation class="amazon-s3-upload">
    <bucket>%message{bucket}</bucket>
    <object-name>%message{key}</object-name>
    <object-metadata>
      <s3-content-type>
        <content-type>%message{Content-Type}</content-type>
      </s3-content-type>
    </object-metadata>
    <object-acl>
      <s3-object-grant>
        <grantee class="s3-object-acl-grantee-owner"/>
        <permission>FULL_CONTROL</permission>
      </s3-object-grant>
      <s3-object-grant>
        <grantee class="s3-object-acl-grantee-canonical-user">
          <id>${account.id}</id>
        </grantee>
        <permission>FULL_CONTROL</permission>
      </s3-object-grant>
    </object-acl>
  </operation>
</amazon-s3-service>
```

```shell
curl -X POST -H "Content-Type: application/json" -d '{"key": "value"}' "http://localhost:8080/api/s3/file.txt"
aws s3api get-object-acl  --bucket bucket --key file.txt
#NOTE: The ability to validate doesn't work with localstack
```