### PR TITLE
deps: switch to using aws-sdk-bom instead of explicit versions for each component

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
   id "io.freefair.lombok" version "6.5.0.3" apply false
   id 'org.owasp.dependencycheck' version '7.1.1' apply false
   id "org.gradle.test-retry" version "1.4.0" apply false
+  id 'nebula.optional-base' version '7.0.0' apply false
 }
 
 ext {
@@ -105,6 +106,7 @@ subprojects {
   apply plugin: 'com.github.spotbugs'
   apply plugin: 'org.owasp.dependencycheck'
   apply plugin: 'org.gradle.test-retry'
+  apply plugin: 'nebula.optional-base'
 
   sourceCompatibility = JavaVersion.VERSION_11
   targetCompatibility = JavaVersion.VERSION_11

--- a/interlok-aws-common/build.gradle
+++ b/interlok-aws-common/build.gradle
@@ -2,29 +2,18 @@ ext {
   componentName = 'Interlok AWS/Common'
   componentDesc = "Common components for accessing AWS"
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
+  awsSDKVersion = '1.12.264'
   jacksonVersion = '2.13.3'
-  awsSDKVersion = '1.12.263'
 }
 
 dependencies {
-  api ("com.amazonaws:aws-java-sdk-core:$awsSDKVersion") {
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
-    exclude group: "com.fasterxml.jackson.dataformat", module: "jackson-dataformat-cbor"
-  }
-  api ("com.amazonaws:aws-java-sdk-sts:$awsSDKVersion") {
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
-    exclude group: "com.fasterxml.jackson.dataformat", module: "jackson-dataformat-cbor"
-  }
   api (platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
+  api (platform("com.amazonaws:aws-java-sdk-bom:$awsSDKVersion"))
+  api ("com.amazonaws:aws-java-sdk-core")
+  api ("com.amazonaws:aws-java-sdk-sts")
   api ("com.fasterxml.jackson.core:jackson-databind")
   api ("com.fasterxml.jackson.core:jackson-core")
   api ("com.fasterxml.jackson.core:jackson-annotations")
-  // It will probably march in lockstep, but since it's a different
-  // group I will make it separate.
   api ("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor")
   api ("com.adaptris:interlok-apache-http:$interlokCoreVersion") { changing = true}
 }

--- a/interlok-aws-kinesis-sdk/build.gradle
+++ b/interlok-aws-kinesis-sdk/build.gradle
@@ -5,30 +5,19 @@ ext {
   componentName = 'Interlok AWS/Kinesis SDK'
   componentDesc = "Components that interact AWS Kinesis data streams via SDK"
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
-  awsSDKVersion = '1.12.263'
+  awsSDKVersion = '1.12.264'
   jacksonVersion = '2.13.3'
 }
 
 dependencies {
-  api ("com.amazonaws:aws-java-sdk-kinesis:$awsSDKVersion") {
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
-    exclude group: "com.fasterxml.jackson.dataformat", module: "jackson-dataformat-cbor"
-  }
-  api ("com.amazonaws:aws-java-sdk-core:$awsSDKVersion") {
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
-    exclude group: "com.fasterxml.jackson.dataformat", module: "jackson-dataformat-cbor"
-  }
-  // Dependency to platform/BOM
   api (platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
+  api (platform("com.amazonaws:aws-java-sdk-bom:$awsSDKVersion"))
+  api ("com.amazonaws:aws-java-sdk-kinesis")
+  api ("com.amazonaws:aws-java-sdk-core")
+  // Dependency to platform/BOM
   api ("com.fasterxml.jackson.core:jackson-databind")
   api ("com.fasterxml.jackson.core:jackson-core")
   api ("com.fasterxml.jackson.core:jackson-annotations")
-  // It will probably march in lockstep, but since it's a different
-  // group I will make it separate.
   api ("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor")
   api project(':interlok-aws-common')
 }

--- a/interlok-aws-kinesis/build.gradle
+++ b/interlok-aws-kinesis/build.gradle
@@ -5,27 +5,24 @@ ext {
   componentName = 'Interlok AWS/Kinesis'
   componentDesc = "Components that interact AWS Kinesis data streams"
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
-  awsSDKVersion = "1.12.263"
-  jacksonVersion = "2.13.3"
   nettyVersion = "4.1.79.Final"
   kotlinVersion = "1.7.10"
   wireVersion = "4.4.0"
+  awsSDKVersion = '1.12.264'
+  jacksonVersion = '2.13.3'
 }
 dependencies {
+  api (platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
+  api (platform("com.amazonaws:aws-java-sdk-bom:$awsSDKVersion"))
   implementation ("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion")
-  
-  api ("com.amazonaws:aws-java-sdk-kinesis:$awsSDKVersion")
+
+  api ("com.amazonaws:aws-java-sdk-kinesis")
+  // The BOM from the parent overrides the 1.12.130 dependency on sdk-s3
   api ("com.amazonaws:amazon-kinesis-client:1.14.8") {
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
-    exclude group: "com.fasterxml.jackson.dataformat", module: "jackson-dataformat-cbor"
     exclude group: "com.google.protobuf", module: "protobuf-java"
   }
-  api ("com.amazonaws:aws-java-sdk-core:$awsSDKVersion") {
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
-    exclude group: "com.fasterxml.jackson.dataformat", module: "jackson-dataformat-cbor"
+
+  api ("com.amazonaws:aws-java-sdk-core") {
     exclude group: "org.apache.avro"
   }
   api ("commons-codec:commons-codec:1.15")
@@ -33,42 +30,38 @@ dependencies {
   // 0.13.1 does containthe windows binaries
   // 0.14 does not contain the windows binary.
   api ("com.amazonaws:amazon-kinesis-producer:0.14.12") {
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
     exclude group: "com.google.protobuf", module: "protobuf-java"
     // Exclude netty so we can pin the version.
     exclude group: "io.netty"
     exclude group: "org.apache.avro"
   }
-
   implementation ("org.apache.avro:avro:1.11.0") {
     exclude group: "org.apache.commons", module: "commons-compress"
   }
-  
+
   implementation ("org.apache.commons:commons-compress:1.21")
 
   api ("com.google.guava:guava:31.1-jre")
-  implementation ("io.netty:netty-buffer:$nettyVersion")
-  implementation ("io.netty:netty-common:$nettyVersion")
-  implementation ("io.netty:netty-handler:$nettyVersion")
-  implementation ("io.netty:netty-transport:$nettyVersion")
-  implementation ("io.netty:netty-transport-native-epoll:$nettyVersion")
-  implementation ("io.netty:netty-transport-native-unix-common:$nettyVersion")
-  implementation ("io.netty:netty-transport-native-kqueue:$nettyVersion")
-  implementation ("io.netty:netty-codec:$nettyVersion")
-  implementation ("io.netty:netty-codec-http:$nettyVersion")
-    
+  implementation (platform("io.netty:netty-bom:$nettyVersion"))
+
+  implementation ("io.netty:netty-buffer")
+  implementation ("io.netty:netty-common")
+  implementation ("io.netty:netty-handler")
+  implementation ("io.netty:netty-transport")
+  implementation ("io.netty:netty-transport-native-epoll")
+  implementation ("io.netty:netty-transport-native-unix-common")
+  implementation ("io.netty:netty-transport-native-kqueue")
+  implementation ("io.netty:netty-codec")
+  implementation ("io.netty:netty-codec-http")
+
   implementation ("com.squareup.wire:wire-schema:$wireVersion")
   implementation ("com.squareup.wire:wire-compiler:$wireVersion")
 
   api ("com.google.protobuf:protobuf-java:3.21.2")
   // Dependency to platform/BOM
-  api (platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
   api ("com.fasterxml.jackson.core:jackson-databind")
   api ("com.fasterxml.jackson.core:jackson-core")
   api ("com.fasterxml.jackson.core:jackson-annotations")
-  // It will probably march in lockstep, but since it's a different
-  // group I will make it separate.
   api ("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor")
   api project(':interlok-aws-common')
 }

--- a/interlok-aws-kms/build.gradle
+++ b/interlok-aws-kms/build.gradle
@@ -5,31 +5,20 @@ ext {
   componentName = 'Interlok AWS/KMS'
   componentDesc = "Components that interact with AWS KMS to perform sign/encrypt/decrypt/verify operations"
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
-  awsSDKVersion = '1.12.263'
+  awsSDKVersion = '1.12.264'
   jacksonVersion = '2.13.3'
 }
 
 dependencies {
   api project(':interlok-aws-common')
-  api ("com.amazonaws:aws-java-sdk-kms:$awsSDKVersion") {
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
-    exclude group: "com.fasterxml.jackson.dataformat", module: "jackson-dataformat-cbor"
-  }
-  api ("com.amazonaws:aws-java-sdk-core:$awsSDKVersion") {
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
-    exclude group: "com.fasterxml.jackson.dataformat", module: "jackson-dataformat-cbor"
-  }
-  // Dependency to platform/BOM
+  api ("com.amazonaws:aws-java-sdk-kms")
+  api ("com.amazonaws:aws-java-sdk-core")
   api (platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
+  api (platform("com.amazonaws:aws-java-sdk-bom:$awsSDKVersion"))
+  // Dependency to platform/BOM
   api ("com.fasterxml.jackson.core:jackson-databind")
   api ("com.fasterxml.jackson.core:jackson-core")
   api ("com.fasterxml.jackson.core:jackson-annotations")
-  // It will probably march in lockstep, but since it's a different
-  // group I will make it separate.
   api ("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor")
 }
 

--- a/interlok-aws-s3/build.gradle
+++ b/interlok-aws-s3/build.gradle
@@ -5,30 +5,19 @@ ext {
   componentName = 'Interlok AWS/S3'
   componentDesc = "Services that interact (upload/download/delete) with AWS S3 Buckets and artefacts"
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
-  awsSDKVersion = '1.12.263'
+  awsSDKVersion = '1.12.264'
   jacksonVersion = '2.13.3'
 }
 
 dependencies {
-  api ("com.amazonaws:aws-java-sdk-s3:$awsSDKVersion") {
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
-    exclude group: "com.fasterxml.jackson.dataformat", module: "jackson-dataformat-cbor"
-  }
-  api ("com.amazonaws:aws-java-sdk-core:$awsSDKVersion") {
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
-    exclude group: "com.fasterxml.jackson.dataformat", module: "jackson-dataformat-cbor"
-  }
-  // Dependency to platform/BOM
   api (platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
+  api (platform("com.amazonaws:aws-java-sdk-bom:$awsSDKVersion"))
+  api ("com.amazonaws:aws-java-sdk-s3")
+  api ("com.amazonaws:aws-java-sdk-core")
+  // Dependency to platform/BOM
   api ("com.fasterxml.jackson.core:jackson-databind")
   api ("com.fasterxml.jackson.core:jackson-core")
   api ("com.fasterxml.jackson.core:jackson-annotations")
-  // It will probably march in lockstep, but since it's a different
-  // group I will make it separate.
   api ("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor")
   api project(':interlok-aws-common')
 }

--- a/interlok-aws-sns/build.gradle
+++ b/interlok-aws-sns/build.gradle
@@ -2,30 +2,19 @@ ext {
   componentName = 'Interlok AWS/SNS'
   componentDesc = "Publishing to AWS SNS topics"
   delombokTargetDir = new File("${project.projectDir}/src/main/generated")
-  awsSDKVersion = '1.12.263'
+  awsSDKVersion = '1.12.264'
   jacksonVersion = '2.13.3'
 }
 
 dependencies {
-  api ("com.amazonaws:aws-java-sdk-sns:$awsSDKVersion") {
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
-    exclude group: "com.fasterxml.jackson.dataformat", module: "jackson-dataformat-cbor"
-  }
-  api ("com.amazonaws:aws-java-sdk-core:$awsSDKVersion") {
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
-    exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
-    exclude group: "com.fasterxml.jackson.dataformat", module: "jackson-dataformat-cbor"
-  }
-  // Dependency to platform/BOM
   api (platform("com.fasterxml.jackson:jackson-bom:$jacksonVersion"))
+  api (platform("com.amazonaws:aws-java-sdk-bom:$awsSDKVersion"))
+  api ("com.amazonaws:aws-java-sdk-sns")
+  api ("com.amazonaws:aws-java-sdk-core")
+  // Dependency to platform/BOM
   api ("com.fasterxml.jackson.core:jackson-databind")
   api ("com.fasterxml.jackson.core:jackson-core")
   api ("com.fasterxml.jackson.core:jackson-annotations")
-  // It will probably march in lockstep, but since it's a different
-  // group I will make it separate.
   api ("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor")
   api project(':interlok-aws-common')
 }


### PR DESCRIPTION
## Motivation

https://github.com/adaptris/interlok-aws/pull/987 shows us that amazon-kinesis-client has a dependency on sdk-s3, which, because we don't have a formal dependency declaration in kinesis, remains pinned at 1.12.130; which is apparently vulnerable.

What's the likelihood of something using _interlok-aws-kinesis_ and using _interlok-aws-s3_ withouth understand dependency management thus leaving them vulnerable to CVE-2022-31159.

(this is quite likely if they use the UI to download the 'package-zip' and extract s3 _before_ kinesis)

## Modification

- Switch to using `com.amazonaws:aws-java-sdk-bom` so we can just refer individual modules w/o a version number
- Switch to using `io.netty:netty-bom` for netty as well.

Dependencies left within each sub-project since there is a PR that includes AWS-SDK-V2 so a hard dependency in the parent for AWS-SDK-V1 is probably a bad thing.

## PR Checklist

- [x] been self-reviewed.


## Result

No change for the user.

## Testing

- `gradle dependencyCheckAnalyze`
- `gradle dependencies` and check the dependencies for amazon-kinesis-client it should now be all .164 rather than .130
