### PR TITLE
INTERLOK-3925 Add support for attributes and group id for SQS and SNS

### DIFF
--- a/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/AwsProducerTest.java
+++ b/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/AwsProducerTest.java
@@ -12,11 +12,12 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.aws.sqs;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -24,12 +25,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 import java.util.ArrayList;
 import java.util.List;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+
 import com.adaptris.aws.AWSKeysAuthentication;
 import com.adaptris.aws.StaticCredentialsBuilder;
 import com.adaptris.core.AdaptrisMessage;
@@ -61,7 +65,7 @@ public class AwsProducerTest extends ExampleProducerCase {
   @Before
   public void setUp() throws Exception {
 
-    producedMessages = new ArrayList<AdaptrisMessage>();
+    producedMessages = new ArrayList<>();
 
     sqsClientMock = mock(AmazonSQSAsync.class);
     GetQueueUrlResult queueUrlResultMock = mock(GetQueueUrlResult.class);
@@ -89,7 +93,7 @@ public class AwsProducerTest extends ExampleProducerCase {
   @Test
   public void testSingleProduceWithException() throws Exception {
     when(sqsClientMock.sendMessageAsync((SendMessageRequest) any()))
-        .thenThrow(new AmazonServiceException("Expected"));
+    .thenThrow(new AmazonServiceException("Expected"));
 
     AmazonSQSProducer producer = initialiseMockProducer();
     try {
@@ -124,34 +128,32 @@ public class AwsProducerTest extends ExampleProducerCase {
     verify(sqsClientMock, times(numMsgs)).sendMessageAsync((SendMessageRequest) any());
   }
 
-  @Test(expected = IllegalArgumentException.class)
   public void testNoConnection() throws Exception {
     when(connectionMock.retrieveConnection(AmazonSQSConnection.class)).thenReturn(null);
-    initialiseMockProducer();
+    assertThrows(IllegalArgumentException.class, () -> initialiseMockProducer());
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testNoDestination() throws Exception {
+  @Test
+  public void testNoQueue() throws Exception {
     AmazonSQSProducer producer = new AmazonSQSProducer();
-    LifecycleHelper.prepare(producer);
-    LifecycleHelper.init(producer);
+    assertThrows(IllegalArgumentException.class, () -> LifecycleHelper.prepare(producer));
   }
 
   @Test
   public void testSingleProduceWithSendAttributes() throws Exception {
     when(sqsClientMock.sendMessageAsync((SendMessageRequest) any()))
-        .thenAnswer(new Answer<Object>() {
+    .thenAnswer(new Answer<Object>() {
       @Override
       public Object answer(InvocationOnMock invocation) {
-          Object[] args = invocation.getArguments();
+        Object[] args = invocation.getArguments();
 
-          SendMessageRequest request = (SendMessageRequest) args[0];
-          assertTrue(request.getMessageAttributes() != null);
-          assertEquals("myValue1", request.getMessageAttributes().get("myKey1").getStringValue());
-          assertEquals("myValue2", request.getMessageAttributes().get("myKey2").getStringValue());
-          assertEquals("myValue3", request.getMessageAttributes().get("myKey3").getStringValue());
+        SendMessageRequest request = (SendMessageRequest) args[0];
+        assertTrue(request.getMessageAttributes() != null);
+        assertEquals("myValue1", request.getMessageAttributes().get("myKey1").getStringValue());
+        assertEquals("myValue2", request.getMessageAttributes().get("myKey2").getStringValue());
+        assertEquals("myValue3", request.getMessageAttributes().get("myKey3").getStringValue());
 
-          return null;
+        return null;
       }
     });
 
@@ -173,18 +175,18 @@ public class AwsProducerTest extends ExampleProducerCase {
   @Test
   public void testSingleProduceWithSendAttributesOneMissing() throws Exception {
     when(sqsClientMock.sendMessageAsync((SendMessageRequest) any()))
-        .thenAnswer(new Answer<Object>() {
+    .thenAnswer(new Answer<Object>() {
       @Override
       public Object answer(InvocationOnMock invocation) {
-          Object[] args = invocation.getArguments();
+        Object[] args = invocation.getArguments();
 
-          SendMessageRequest request = (SendMessageRequest) args[0];
-          assertTrue(request.getMessageAttributes() != null);
-          assertEquals("myValue1", request.getMessageAttributes().get("myKey1").getStringValue());
-          assertNull(request.getMessageAttributes().get("myKey2"));
-          assertEquals("myValue3", request.getMessageAttributes().get("myKey3").getStringValue());
+        SendMessageRequest request = (SendMessageRequest) args[0];
+        assertTrue(request.getMessageAttributes() != null);
+        assertEquals("myValue1", request.getMessageAttributes().get("myKey1").getStringValue());
+        assertNull(request.getMessageAttributes().get("myKey2"));
+        assertEquals("myValue3", request.getMessageAttributes().get("myKey3").getStringValue());
 
-          return null;
+        return null;
       }
     });
 
@@ -206,18 +208,18 @@ public class AwsProducerTest extends ExampleProducerCase {
   @Test
   public void testSingleProduceWithSendAttributesOneEmpty() throws Exception {
     when(sqsClientMock.sendMessageAsync((SendMessageRequest) any()))
-        .thenAnswer(new Answer<Object>() {
+    .thenAnswer(new Answer<Object>() {
       @Override
       public Object answer(InvocationOnMock invocation) {
-          Object[] args = invocation.getArguments();
+        Object[] args = invocation.getArguments();
 
-          SendMessageRequest request = (SendMessageRequest) args[0];
-          assertTrue(request.getMessageAttributes() != null);
-          assertEquals("myValue1", request.getMessageAttributes().get("myKey1").getStringValue());
-          assertNull(request.getMessageAttributes().get("myKey2"));
-          assertEquals("myValue3", request.getMessageAttributes().get("myKey3").getStringValue());
+        SendMessageRequest request = (SendMessageRequest) args[0];
+        assertTrue(request.getMessageAttributes() != null);
+        assertEquals("myValue1", request.getMessageAttributes().get("myKey1").getStringValue());
+        assertNull(request.getMessageAttributes().get("myKey2"));
+        assertEquals("myValue3", request.getMessageAttributes().get("myKey3").getStringValue());
 
-          return null;
+        return null;
       }
     });
 
@@ -250,8 +252,9 @@ public class AwsProducerTest extends ExampleProducerCase {
 
   private AdaptrisMessage createMessage(MetadataElement ... metadataElements ){
     AdaptrisMessage msg = this.createMessage();
-    for(MetadataElement element : metadataElements)
+    for(MetadataElement element : metadataElements) {
       msg.addMetadata(element);
+    }
     return msg;
   }
 


### PR DESCRIPTION
….

Add tests, javadocs and refactoring

## Motivation

- SQS FIFO is not working as the group id cannot be specified.
- Metadata cannot be passed to SNS as message attributes.

## Modification

- Add support for group id for SQS
- Add support for group id and attributes for SNS
- Add tests, javadocs and refactoring

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [x] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI

## Result

- SQS FIFO should work if the group id is specified.
- String metadata can be passed to SNS message via attributes. Working in the same way as for SQS.

## Testing

AR is testing it
