### PR TITLE
Java 17 and junit 5 upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,113 +7,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/openjdk:8-jdk
-
-    working_directory: ~/project
-
-    environment:
-      JAVA_TOOL_OPTIONS: -Xmx2G -Djava.security.egd=file:/dev/./urandom
-      TERM: dumb
-
-    steps:
-      - checkout
-
-      - run:
-          name: Configure
-          command: |
-            mkdir -p ~/.gradle
-            echo "org.gradle.warning.mode=none" > ~/.gradle/gradle.properties
-
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - dependencies-{{ .Environment.CIRCLE_JOB}}-{{ checksum "build.gradle" }}
-            - dependencies-{{ .Environment.CIRCLE_JOB}}-
-            - dependencies-
-
-      # run tests!
-      - run:
-          name: Run Tests
-          command: |
-            chmod +x ./gradlew
-            ./gradlew -PverboseTests=true test jacocoTestReport
-
-      - run:
-          name: Save test results
-          command: |
-            mkdir -p ~/test-results/junit/
-            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/test-results/junit/ \;
-          when: always
-
-      - store_test_results:
-          path: ~/test-results
-
-      - run:
-          name: codecov.io
-          command: bash <(curl -s https://codecov.io/bash)
-
-      - save_cache:
-          paths:
-            - ~/.gradle/caches
-            - ~/.gradle/wrapper
-          key: dependencies-{{ .Environment.CIRCLE_JOB}}-{{ checksum "build.gradle" }}
-
-  publish:
-    docker:
-      - image: circleci/openjdk:8-jdk
-
-    working_directory: ~/project
-
-    environment:
-      JAVA_TOOL_OPTIONS: -Xmx2G -Djava.security.egd=file:/dev/./urandom
-      TERM: dumb
-
-    steps:
-      - checkout
-
-      - run:
-          name: Configure
-          command: |
-            sudo apt-get -y update
-            sudo apt-get -y install graphviz
-            mkdir -p ~/.gradle
-            echo "org.gradle.warning.mode=none" > ~/.gradle/gradle.properties
-
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - dependencies-{{ .Environment.CIRCLE_JOB}}-{{ checksum "build.gradle" }}
-            - dependencies-{{ .Environment.CIRCLE_JOB}}-
-            - dependencies-
-
-      # run tests!
-      - run:
-          name: Publish
-          command: |
-            chmod +x ./gradlew
-            ./gradlew -PverboseTests=true test publish
-
-      - run:
-          name: Save test results
-          command: |
-            mkdir -p ~/test-results/junit/
-            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/test-results/junit/ \;
-          when: always
-
-      - store_test_results:
-          path: ~/test-results
-
-      - save_cache:
-          paths:
-            - ~/.gradle/caches
-            - ~/.gradle/wrapper
-          key: dependencies-{{ .Environment.CIRCLE_JOB}}-{{ checksum "build.gradle" }}
-
-  buildjava11:
-    docker:
-      - image: circleci/openjdk:11-jdk
+      - image: circleci/openjdk:17-jdk
 
     working_directory: ~/project
 
@@ -161,9 +55,9 @@ jobs:
             - ~/.gradle/wrapper
           key: dependencies-{{ .Environment.CIRCLE_JOB}}-{{ checksum "build.gradle" }}
 
+
 workflows:
   version: 2
   on_commit:
     jobs:
       - build
-      - buildjava11

--- a/build.gradle
+++ b/build.gradle
@@ -108,8 +108,8 @@ subprojects {
   apply plugin: 'org.gradle.test-retry'
   apply plugin: 'nebula.optional-base'
 
-  sourceCompatibility = JavaVersion.VERSION_11
-  targetCompatibility = JavaVersion.VERSION_11
+  sourceCompatibility = JavaVersion.VERSION_17
+  targetCompatibility = JavaVersion.VERSION_17
   group   = 'com.adaptris'
   version = releaseVersion
   def versionDir = "$buildDir/version"
@@ -162,7 +162,8 @@ subprojects {
     implementation ("org.slf4j:jcl-over-slf4j:$slf4jVersion")
 
     annotationProcessor ("com.adaptris:interlok-core-apt:$interlokCoreVersion") { changing= true}
-    testImplementation ('junit:junit:4.13.2')
+    testImplementation ("org.junit.jupiter:junit-jupiter-api:5.9.2")
+    testImplementation ("org.junit.jupiter:junit-jupiter-engine:5.9.2")
     testImplementation "org.slf4j:slf4j-simple:$slf4jVersion"
     testImplementation ("com.adaptris:interlok-stubs:$interlokCoreVersion") { changing= true }
     testImplementation ("org.slf4j:jcl-over-slf4j:$slf4jVersion")
@@ -224,6 +225,11 @@ subprojects {
       options.addStringOption "umlIncludePackagePrivateInnerClasses", "false"
       options.addStringOption "umlIncludeProtectedInnerClasses","false"
     }
+  }
+  
+  test {
+  jvmArgs = ['--add-opens', 'java.base/java.lang=ALL-UNNAMED', '--add-opens', 'java.base/java.util=ALL-UNNAMED']
+  useJUnitPlatform()
   }
 
   jacocoTestReport {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -14,7 +14,7 @@
 @rem limitations under the License.
 @rem
 
-@if "%DEBUG%" == "" @echo off
+@if "%DEBUG%"=="" @echo off
 @rem ##########################################################################
 @rem
 @rem  Gradle startup script for Windows
@@ -25,7 +25,8 @@
 if "%OS%"=="Windows_NT" setlocal
 
 set DIRNAME=%~dp0
-if "%DIRNAME%" == "" set DIRNAME=.
+if "%DIRNAME%"=="" set DIRNAME=.
+@rem This is normally unused
 set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 
@@ -40,7 +41,7 @@ if defined JAVA_HOME goto findJavaFromJavaHome
 
 set JAVA_EXE=java.exe
 %JAVA_EXE% -version >NUL 2>&1
-if "%ERRORLEVEL%" == "0" goto execute
+if %ERRORLEVEL% equ 0 goto execute
 
 echo.
 echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
@@ -75,13 +76,15 @@ set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
 :end
 @rem End local scope for the variables with windows NT shell
-if "%ERRORLEVEL%"=="0" goto mainEnd
+if %ERRORLEVEL% equ 0 goto mainEnd
 
 :fail
 rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
 rem the _cmd.exe /c_ return code!
-if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
-exit /b 1
+set EXIT_CODE=%ERRORLEVEL%
+if %EXIT_CODE% equ 0 set EXIT_CODE=1
+if not ""=="%GRADLE_EXIT_CONSOLE%" exit %EXIT_CODE%
+exit /b %EXIT_CODE%
 
 :mainEnd
 if "%OS%"=="Windows_NT" endlocal

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/AwsConnectionTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/AwsConnectionTest.java
@@ -1,11 +1,11 @@
 package com.adaptris.aws;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import com.adaptris.core.CoreException;
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.KeyValuePairSet;
@@ -13,11 +13,11 @@ import com.amazonaws.client.builder.AwsClientBuilder;
 
 public class AwsConnectionTest extends AWSConnection {
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
   }
 

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/AwsKeysAuthenticationTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/AwsKeysAuthenticationTest.java
@@ -1,8 +1,8 @@
 package com.adaptris.aws;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import org.junit.jupiter.api.Test;
 
 public class AwsKeysAuthenticationTest {
 

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/ClientConfigurationBuilderTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/ClientConfigurationBuilderTest.java
@@ -1,8 +1,8 @@
 package com.adaptris.aws;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.KeyValuePairSet;
 import com.amazonaws.ClientConfiguration;

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/ClientConfigurationPropertiesTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/ClientConfigurationPropertiesTest.java
@@ -1,12 +1,12 @@
 package com.adaptris.aws;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.net.URL;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import com.adaptris.aws.ClientConfigurationBuilder.ClientConfigurationProperties;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.Protocol;

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/CustomEndpointTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/CustomEndpointTest.java
@@ -16,12 +16,12 @@
 
 package com.adaptris.aws;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 import com.amazonaws.client.builder.AwsClientBuilder;
 
 public class CustomEndpointTest  {

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/DefaultAwsAuthenticationTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/DefaultAwsAuthenticationTest.java
@@ -1,7 +1,7 @@
 package com.adaptris.aws;
 
-import static org.junit.Assert.assertNull;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import org.junit.jupiter.api.Test;
 
 public class DefaultAwsAuthenticationTest {
 

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/DefaultRetryPolicyFactoryTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/DefaultRetryPolicyFactoryTest.java
@@ -1,7 +1,7 @@
 package com.adaptris.aws;
 
-import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.junit.jupiter.api.Test;
 import com.adaptris.aws.DefaultRetryPolicyFactory.PredefinedPolicy;
 
 public class DefaultRetryPolicyFactoryTest {

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/PluggableRetryPolicyFactoryTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/PluggableRetryPolicyFactoryTest.java
@@ -1,7 +1,10 @@
 package com.adaptris.aws;
 
-import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
 
 public class PluggableRetryPolicyFactoryTest {
 
@@ -22,11 +25,13 @@ public class PluggableRetryPolicyFactoryTest {
     assertNotNull(retry.build());
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testBuild_ClassNotFound() throws Exception {
     PluggableRetryPolicyFactory retry = new PluggableRetryPolicyFactory().withMaxErrorRetry(99)
         .withUseClientConfigurationMaxErrorRetry(true).withBackoffStrategyClass("com.Blah");
-    retry.build();
+    assertThrows(RuntimeException.class, ()->{
+      retry.build();
+    }, "Failed to build, class not found");
   }
 
 }

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/ProcessCredentialsBuilderTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/ProcessCredentialsBuilderTest.java
@@ -1,17 +1,21 @@
 package com.adaptris.aws;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.ProcessCredentialsProvider;
 
 public class ProcessCredentialsBuilderTest {
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBuild_Defaults() throws Exception {
     ProcessCredentialsBuilder auth = new ProcessCredentialsBuilder();
-    AWSCredentialsProvider provider = auth.build();
+    assertThrows(IllegalArgumentException.class, ()->{
+      AWSCredentialsProvider provider = auth.build();
+    }, "Failed to build");
   }
 
   @Test

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/ProfileCredentialsBuilderTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/ProfileCredentialsBuilderTest.java
@@ -1,11 +1,11 @@
 package com.adaptris.aws;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import com.adaptris.core.stubs.TempFileUtils;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/PropertiesFileCredentialsBuilderTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/PropertiesFileCredentialsBuilderTest.java
@@ -1,11 +1,14 @@
 package com.adaptris.aws;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 import com.adaptris.core.stubs.TempFileUtils;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.ClasspathPropertiesFileCredentialsProvider;
@@ -13,10 +16,12 @@ import com.amazonaws.auth.PropertiesFileCredentialsProvider;
 
 public class PropertiesFileCredentialsBuilderTest {
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBuild_Defaults() throws Exception {
     PropertiesFileCredentialsBuilder auth = new PropertiesFileCredentialsBuilder();
-    AWSCredentialsProvider provider = auth.build();
+    assertThrows(IllegalArgumentException.class, ()->{
+      AWSCredentialsProvider provider = auth.build();
+    }, "Failed to build");
   }
 
   @Test

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/RetryNotFoundPolicyFactoryTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/RetryNotFoundPolicyFactoryTest.java
@@ -1,10 +1,10 @@
 package com.adaptris.aws;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import org.apache.http.HttpStatus;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.retry.RetryPolicy;

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/STSCredentialsBuilderTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/STSCredentialsBuilderTest.java
@@ -16,9 +16,9 @@
 
 package com.adaptris.aws;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.util.Arrays;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import com.adaptris.util.KeyValuePair;
 import com.adaptris.util.KeyValuePairSet;
 import com.amazonaws.SDKGlobalConfiguration;

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/StaticCredentialsBuilderTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/StaticCredentialsBuilderTest.java
@@ -1,9 +1,9 @@
 package com.adaptris.aws;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import org.junit.jupiter.api.Test;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;

--- a/interlok-aws-common/src/test/java/com/adaptris/aws/apache/interceptor/SigningnterceptorBuilderTest.java
+++ b/interlok-aws-common/src/test/java/com/adaptris/aws/apache/interceptor/SigningnterceptorBuilderTest.java
@@ -1,9 +1,11 @@
 package com.adaptris.aws.apache.interceptor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.apache.http.HttpRequestInterceptor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import com.adaptris.aws.AWSCredentialsProviderBuilder;
 import com.adaptris.aws.STSAssumeroleCredentialsBuilder;
 import com.adaptris.aws.StaticCredentialsBuilder;
@@ -23,12 +25,14 @@ public class SigningnterceptorBuilderTest {
 
   }
 
-  @Test(expected=Exception.class)
+  @Test
   public void testBuild_Exception() {
     ApacheSigningInterceptor builder =
         new ApacheSigningInterceptor().withRegion("region").withService("service")
             .withCredentials(new FailingCredentialsBuilder());
-    HttpRequestInterceptor interceptor = builder.build();
+    assertThrows(Exception.class, ()->{
+      HttpRequestInterceptor interceptor = builder.build();
+    }, "Failed to build");
   }
 
   @Test

--- a/interlok-aws-kinesis-sdk/src/test/java/com/adaptris/aws/kinesis/AWSKinesisSDKConnectionTest.java
+++ b/interlok-aws-kinesis-sdk/src/test/java/com/adaptris/aws/kinesis/AWSKinesisSDKConnectionTest.java
@@ -21,11 +21,11 @@ import com.adaptris.aws.StaticCredentialsBuilder;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.interlok.junit.scaffolding.BaseCase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class AWSKinesisSDKConnectionTest extends BaseCase {
 

--- a/interlok-aws-kinesis-sdk/src/test/java/com/adaptris/aws/kinesis/KinesisSDKStreamProducerTest.java
+++ b/interlok-aws-kinesis-sdk/src/test/java/com/adaptris/aws/kinesis/KinesisSDKStreamProducerTest.java
@@ -1,14 +1,14 @@
 package com.adaptris.aws.kinesis;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import com.adaptris.aws.AWSKeysAuthentication;

--- a/interlok-aws-kinesis-sdk/src/test/java/com/adaptris/aws/kinesis/LocalstackTest.java
+++ b/interlok-aws-kinesis-sdk/src/test/java/com/adaptris/aws/kinesis/LocalstackTest.java
@@ -1,5 +1,8 @@
 package com.adaptris.aws.kinesis;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import com.adaptris.aws.AWSKeysAuthentication;
 import com.adaptris.aws.CustomEndpoint;
 import com.adaptris.aws.StaticCredentialsBuilder;
@@ -17,21 +20,19 @@ import com.amazonaws.services.kinesis.model.GetShardIteratorRequest;
 import com.amazonaws.services.kinesis.model.Shard;
 import com.amazonaws.services.kinesis.model.ShardIteratorType;
 import org.apache.commons.lang3.BooleanUtils;
-import org.junit.After;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class LocalstackTest {
 
   private static final String TESTS_ENABLED = "localstack.tests.enabled";
@@ -47,15 +48,15 @@ public class LocalstackTest {
 
   private transient AWSKinesisSDKConnection connection;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
-    Assume.assumeTrue(areTestsEnabled());
+    assumeTrue(areTestsEnabled());
     System.setProperty(SDKGlobalConfiguration.AWS_CBOR_DISABLE_SYSTEM_PROPERTY, "true");
     this.connection = connection();
     LifecycleHelper.initAndStart(connection);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     LifecycleHelper.stopAndClose(connection);
     System.clearProperty(SDKGlobalConfiguration.AWS_CBOR_DISABLE_SYSTEM_PROPERTY);

--- a/interlok-aws-kinesis-sdk/src/test/java/com/adaptris/aws/kinesis/SplittingRequestBuilderTest.java
+++ b/interlok-aws-kinesis-sdk/src/test/java/com/adaptris/aws/kinesis/SplittingRequestBuilderTest.java
@@ -4,9 +4,9 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.services.splitter.NoOpSplitter;
 import com.amazonaws.services.kinesis.model.PutRecordsRequestEntry;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SplittingRequestBuilderTest {
 

--- a/interlok-aws-kinesis/src/test/java/com/adaptris/aws/kinesis/ConnectionFromPropertiesTest.java
+++ b/interlok-aws-kinesis/src/test/java/com/adaptris/aws/kinesis/ConnectionFromPropertiesTest.java
@@ -16,13 +16,13 @@
 
 package com.adaptris.aws.kinesis;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.interlok.junit.scaffolding.util.Os;

--- a/interlok-aws-kinesis/src/test/java/com/adaptris/aws/kinesis/InlineConnectionTest.java
+++ b/interlok-aws-kinesis/src/test/java/com/adaptris/aws/kinesis/InlineConnectionTest.java
@@ -16,10 +16,10 @@
 
 package com.adaptris.aws.kinesis;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import org.junit.jupiter.api.Test;
 import com.adaptris.aws.StaticCredentialsBuilder;
 import com.adaptris.core.util.LifecycleHelper;
 import com.adaptris.interlok.junit.scaffolding.util.Os;

--- a/interlok-aws-kinesis/src/test/java/com/adaptris/aws/kinesis/KinesisStreamProducerTest.java
+++ b/interlok-aws-kinesis/src/test/java/com/adaptris/aws/kinesis/KinesisStreamProducerTest.java
@@ -1,9 +1,9 @@
 package com.adaptris.aws.kinesis;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;

--- a/interlok-aws-kinesis/src/test/java/com/adaptris/aws/kinesis/KinesisSynchronousStreamProducerTest.java
+++ b/interlok-aws-kinesis/src/test/java/com/adaptris/aws/kinesis/KinesisSynchronousStreamProducerTest.java
@@ -1,12 +1,12 @@
 package com.adaptris.aws.kinesis;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;

--- a/interlok-aws-kms/src/test/java/com/adaptris/aws/kms/ByteBufferInputStreamTest.java
+++ b/interlok-aws-kms/src/test/java/com/adaptris/aws/kms/ByteBufferInputStreamTest.java
@@ -4,7 +4,7 @@ import static com.adaptris.aws.kms.LocalstackHelper.MSG_CONTENTS;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ByteBufferInputStreamTest {
 

--- a/interlok-aws-kms/src/test/java/com/adaptris/aws/kms/DecryptServiceTest.java
+++ b/interlok-aws-kms/src/test/java/com/adaptris/aws/kms/DecryptServiceTest.java
@@ -2,14 +2,15 @@ package com.adaptris.aws.kms;
 
 import static com.adaptris.aws.kms.LocalstackHelper.MSG_CONTENTS;
 import static com.adaptris.aws.kms.LocalstackHelper.hash;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import java.nio.ByteBuffer;
 import java.util.EnumSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -58,7 +59,7 @@ public class DecryptServiceTest extends ExampleServiceCase {
     assertNotEquals(MSG_CONTENTS, msg.getContent());
   }
 
-  @Test(expected = ServiceException.class)
+  @Test
   public void testSign_Broken() throws Exception {
     AWSKMSClient client = Mockito.mock(AWSKMSClient.class);
 
@@ -69,7 +70,9 @@ public class DecryptServiceTest extends ExampleServiceCase {
     AdaptrisMessage msg = new DefectiveMessageFactory(EnumSet.of(WhenToBreak.METADATA_GET)).newMessage(MSG_CONTENTS);
 
     DecryptService service = retrieveObjectForSampleConfig().withEncryptionContext(null).withConnection(connectionMock);
-    execute(service, msg);
+    assertThrows(ServiceException.class, ()->{
+      execute(service, msg);
+    }, "Failed, signing is broken");
   }
 
 

--- a/interlok-aws-kms/src/test/java/com/adaptris/aws/kms/EncryptServiceTest.java
+++ b/interlok-aws-kms/src/test/java/com/adaptris/aws/kms/EncryptServiceTest.java
@@ -2,14 +2,15 @@ package com.adaptris.aws.kms;
 
 import static com.adaptris.aws.kms.LocalstackHelper.MSG_CONTENTS;
 import static com.adaptris.aws.kms.LocalstackHelper.hash;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import java.nio.ByteBuffer;
 import java.util.EnumSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -58,7 +59,7 @@ public class EncryptServiceTest extends ExampleServiceCase {
     assertNotEquals(MSG_CONTENTS, msg.getContent());
   }
 
-  @Test(expected = ServiceException.class)
+  @Test
   public void testSign_Broken() throws Exception {
     AWSKMSClient client = Mockito.mock(AWSKMSClient.class);
 
@@ -69,7 +70,9 @@ public class EncryptServiceTest extends ExampleServiceCase {
     AdaptrisMessage msg = new DefectiveMessageFactory(EnumSet.of(WhenToBreak.METADATA_GET)).newMessage(MSG_CONTENTS);
 
     EncryptService service = retrieveObjectForSampleConfig().withEncryptionContext(null).withConnection(connectionMock);
-    execute(service, msg);
+    assertThrows(ServiceException.class, ()->{
+      execute(service, msg);
+    }, "Failed, signing is broken");
   }
 
 

--- a/interlok-aws-kms/src/test/java/com/adaptris/aws/kms/KMSConnectionTest.java
+++ b/interlok-aws-kms/src/test/java/com/adaptris/aws/kms/KMSConnectionTest.java
@@ -16,10 +16,10 @@
 
 package com.adaptris.aws.kms;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
 import com.adaptris.aws.AWSKeysAuthentication;
 import com.adaptris.aws.StaticCredentialsBuilder;
 import com.adaptris.core.CoreException;

--- a/interlok-aws-kms/src/test/java/com/adaptris/aws/kms/LocalstackEncryptionTest.java
+++ b/interlok-aws-kms/src/test/java/com/adaptris/aws/kms/LocalstackEncryptionTest.java
@@ -7,12 +7,13 @@ import static com.adaptris.aws.kms.LocalstackHelper.MSG_CONTENTS;
 import static com.adaptris.aws.kms.LocalstackHelper.areTestsEnabled;
 import static com.adaptris.aws.kms.LocalstackHelper.assertEqual;
 import static com.adaptris.aws.kms.LocalstackHelper.assertNotEqual;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import java.nio.charset.StandardCharsets;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import com.adaptris.aws.AWSKeysAuthentication;
 import com.adaptris.aws.CustomEndpoint;
 import com.adaptris.aws.StaticCredentialsBuilder;
@@ -25,20 +26,19 @@ import com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase;
 import com.amazonaws.services.kms.AWSKMSClient;
 import com.amazonaws.services.kms.model.CreateKeyRequest;
 import com.amazonaws.services.kms.model.CreateKeyResult;
-import com.amazonaws.services.kms.model.CustomerMasterKeySpec;
 import com.amazonaws.services.kms.model.KeyUsageType;
 import com.amazonaws.services.kms.model.OriginType;
 
 // Note that local uses local-kms under the covers
 // https://github.com/nsmithuk/local-kms explicitly states that asymmetric operations are not supported.
 // So we just test using a symmetric key / default.
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class LocalstackEncryptionTest {
 
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
-    Assume.assumeTrue(areTestsEnabled());
+    assumeTrue(areTestsEnabled());
   }
 
   @Test
@@ -96,7 +96,6 @@ public class LocalstackEncryptionTest {
     CreateKeyRequest req = new CreateKeyRequest().withDescription("junit")
         .withKeyUsage(KeyUsageType.ENCRYPT_DECRYPT)
         .withBypassPolicyLockoutSafetyCheck(true)
-        .withCustomerMasterKeySpec(CustomerMasterKeySpec.SYMMETRIC_DEFAULT)
         .withOrigin(OriginType.AWS_KMS);
     CreateKeyResult result = client.createKey(req);
     return result.getKeyMetadata().getKeyId();

--- a/interlok-aws-kms/src/test/java/com/adaptris/aws/kms/LocalstackHelper.java
+++ b/interlok-aws-kms/src/test/java/com/adaptris/aws/kms/LocalstackHelper.java
@@ -1,7 +1,7 @@
 package com.adaptris.aws.kms;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;

--- a/interlok-aws-kms/src/test/java/com/adaptris/aws/kms/LocalstackSigningTest.java
+++ b/interlok-aws-kms/src/test/java/com/adaptris/aws/kms/LocalstackSigningTest.java
@@ -7,14 +7,14 @@ import static com.adaptris.aws.kms.LocalstackHelper.KMS_URL;
 import static com.adaptris.aws.kms.LocalstackHelper.MSG_CONTENTS;
 import static com.adaptris.aws.kms.LocalstackHelper.SIG_METADATA_KEY;
 import static com.adaptris.aws.kms.LocalstackHelper.hash;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import com.adaptris.aws.AWSKeysAuthentication;
 import com.adaptris.aws.CustomEndpoint;
 import com.adaptris.aws.StaticCredentialsBuilder;
@@ -28,7 +28,6 @@ import com.adaptris.util.text.Base64ByteTranslator;
 import com.amazonaws.services.kms.AWSKMSClient;
 import com.amazonaws.services.kms.model.CreateKeyRequest;
 import com.amazonaws.services.kms.model.CreateKeyResult;
-import com.amazonaws.services.kms.model.CustomerMasterKeySpec;
 import com.amazonaws.services.kms.model.KeyUsageType;
 import com.amazonaws.services.kms.model.MessageType;
 import com.amazonaws.services.kms.model.OriginType;
@@ -37,12 +36,12 @@ import com.amazonaws.services.kms.model.SigningAlgorithmSpec;
 // Note that local uses local-kms under the covers
 // https://github.com/nsmithuk/local-kms explicitly states that asymmetric operations are not supported.
 // So this conceptually is correct; but it won't work.
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class LocalstackSigningTest {
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
-    Assume.assumeTrue(false);
+    assumeTrue(false);
     // Assume.assumeTrue(areTestsEnabled());
   }
 
@@ -104,7 +103,6 @@ public class LocalstackSigningTest {
     CreateKeyRequest req = new CreateKeyRequest().withDescription("junit")
         .withKeyUsage(KeyUsageType.SIGN_VERIFY)
         .withBypassPolicyLockoutSafetyCheck(true)
-        .withCustomerMasterKeySpec(CustomerMasterKeySpec.RSA_2048)
         .withOrigin(OriginType.AWS_KMS);
     CreateKeyResult result = client.createKey(req);
     System.err.println(result.getKeyMetadata().getSigningAlgorithms());

--- a/interlok-aws-kms/src/test/java/com/adaptris/aws/kms/SigningServiceTest.java
+++ b/interlok-aws-kms/src/test/java/com/adaptris/aws/kms/SigningServiceTest.java
@@ -4,14 +4,15 @@ import static com.adaptris.aws.kms.LocalstackHelper.HASH_METADATA_KEY;
 import static com.adaptris.aws.kms.LocalstackHelper.MSG_CONTENTS;
 import static com.adaptris.aws.kms.LocalstackHelper.SIG_METADATA_KEY;
 import static com.adaptris.aws.kms.LocalstackHelper.hash;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import java.nio.ByteBuffer;
 import java.util.Base64;
 import java.util.EnumSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -91,7 +92,7 @@ public class SigningServiceTest extends ExampleServiceCase {
 
   }
 
-  @Test(expected = ServiceException.class)
+  @Test
   public void testSign_Broken() throws Exception {
     AWSKMSClient client = Mockito.mock(AWSKMSClient.class);
     AdaptrisMessage msg =
@@ -103,7 +104,9 @@ public class SigningServiceTest extends ExampleServiceCase {
     when(connectionMock.awsClient()).thenReturn(client);
 
     GenerateSignatureService service = retrieveObjectForSampleConfig().withConnection(connectionMock);
-    execute(service, msg);
+    assertThrows(ServiceException.class, ()->{
+      execute(service, msg);
+    }, "Failed, signing is broken");
   }
 
 }

--- a/interlok-aws-kms/src/test/java/com/adaptris/aws/kms/VerifyServiceTest.java
+++ b/interlok-aws-kms/src/test/java/com/adaptris/aws/kms/VerifyServiceTest.java
@@ -4,12 +4,13 @@ import static com.adaptris.aws.kms.LocalstackHelper.HASH_METADATA_KEY;
 import static com.adaptris.aws.kms.LocalstackHelper.MSG_CONTENTS;
 import static com.adaptris.aws.kms.LocalstackHelper.SIG_METADATA_KEY;
 import static com.adaptris.aws.kms.LocalstackHelper.hash;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import java.util.Base64;
 import java.util.EnumSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -81,7 +82,7 @@ public class VerifyServiceTest extends ExampleServiceCase {
 
   }
 
-  @Test(expected = ServiceException.class)
+  @Test
   public void testSign_InvalidSignature() throws Exception {
     AWSKMSClient client = Mockito.mock(AWSKMSClient.class);
     VerifyResult result = new VerifyResult().withKeyId("keyId")
@@ -98,10 +99,12 @@ public class VerifyServiceTest extends ExampleServiceCase {
     msg.addMessageHeader(HASH_METADATA_KEY, Base64.getEncoder().encodeToString(hash(MSG_CONTENTS)));
 
     VerifySignatureService service = retrieveObjectForSampleConfig().withConnection(connectionMock);
-    execute(service, msg);
+    assertThrows(ServiceException.class, ()->{
+      execute(service, msg);
+    }, "Failed, invalid signature");
   }
 
-  @Test(expected = ServiceException.class)
+  @Test
   public void testVerify_Broken() throws Exception {
     AWSKMSClient client = Mockito.mock(AWSKMSClient.class);
 
@@ -113,7 +116,9 @@ public class VerifyServiceTest extends ExampleServiceCase {
     msg.addMessageHeader(HASH_METADATA_KEY, Base64.getEncoder().encodeToString(hash(MSG_CONTENTS)));
 
     VerifySignatureService service = retrieveObjectForSampleConfig().withConnection(connectionMock);
-    execute(service, msg);
+    assertThrows(ServiceException.class, ()->{
+      execute(service, msg);
+    }, "Failed, verify broken");
   }
 
 

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/AmazonS3ConnectionTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/AmazonS3ConnectionTest.java
@@ -16,10 +16,10 @@
 
 package com.adaptris.aws.s3;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
 import com.adaptris.aws.AWSKeysAuthentication;
 import com.adaptris.aws.StaticCredentialsBuilder;
 import com.adaptris.core.CoreException;

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/BucketListTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/BucketListTest.java
@@ -1,9 +1,10 @@
 package com.adaptris.aws.s3;
 
 import static com.adaptris.aws.s3.MockedOperationTest.createSummary;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import java.io.StringReader;
 import java.util.ArrayList;
@@ -13,12 +14,11 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.filefilter.RegexFileFilter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
-import com.adaptris.core.ServiceCase;
 import com.adaptris.core.ServiceException;
 import com.adaptris.interlok.cloud.BlobListRenderer;
 import com.adaptris.interlok.cloud.RemoteBlobFilterWrapper;
@@ -27,7 +27,7 @@ import com.amazonaws.services.s3.model.ListObjectsV2Request;
 import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 
-@SuppressWarnings("deprecation")
+
 public class BucketListTest {
 
   @Test
@@ -49,7 +49,7 @@ public class BucketListTest {
         new S3BucketList().withConnection(mockConnection).withBucket("srcBucket")
             .withPrefix("srcKeyPrefix").withOutputStyle(null);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-    ServiceCase.execute(bucket, msg);
+    S3ServiceTest.execute(bucket, msg);
 
     Mockito.verify(client, Mockito.times(1)).listObjectsV2(any(ListObjectsV2Request.class));
     assertEquals("srcBucket", argument.getValue().getBucketName());
@@ -80,7 +80,7 @@ public class BucketListTest {
         new S3BucketList().withConnection(mockConnection).withBucket("srcBucket")
             .withPrefix("srcKeyPrefix").withFilter(filter);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-    ServiceCase.execute(bucket, msg);
+    S3ServiceTest.execute(bucket, msg);
 
     Mockito.verify(client, Mockito.times(1)).listObjectsV2(any(ListObjectsV2Request.class));
     assertEquals("srcBucket", argument.getValue().getBucketName());
@@ -91,7 +91,7 @@ public class BucketListTest {
     assertEquals(1, lines.size());
   }
 
-  @Test(expected = ServiceException.class)
+  @Test
   public void testService_Failure() throws Exception {
     AmazonS3Connection mockConnection = Mockito.mock(AmazonS3Connection.class);
     AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
@@ -111,7 +111,9 @@ public class BucketListTest {
     Mockito.when(client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(listing);
 
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-    ServiceCase.execute(bucket, msg);
+    assertThrows(ServiceException.class, ()->{
+      S3ServiceTest.execute(bucket, msg);
+    }, "Failed to write to bucket");
   }
 
   @Test
@@ -132,7 +134,7 @@ public class BucketListTest {
         new S3BucketList().withConnection(mockConnection).withBucket("srcBucket")
             .withPrefix("srcKeyPrefix").withMaxKeys(2).withOutputStyle(null);
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-    ServiceCase.execute(bucket, msg);
+    S3ServiceTest.execute(bucket, msg);
 
     Mockito.verify(client, Mockito.times(1)).listObjectsV2(any(ListObjectsV2Request.class));
     assertEquals("srcBucket", argument.getValue().getBucketName());
@@ -174,7 +176,7 @@ public class BucketListTest {
             .withPrefix("srcKeyPrefix").withMaxKeys(2)
             .withOutputStyle(null).withBucket("srcBucket");
     AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
-    ServiceCase.execute(bucket, msg);
+    S3ServiceTest.execute(bucket, msg);
 
     Mockito.verify(client, Mockito.times(2)).listObjectsV2(any(ListObjectsV2Request.class));
 

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/LocalstackServiceTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/LocalstackServiceTest.java
@@ -11,15 +11,16 @@ import static com.adaptris.aws.s3.LocalstackConfig.build;
 import static com.adaptris.aws.s3.LocalstackConfig.extendedCopyTests;
 import static com.adaptris.aws.s3.LocalstackConfig.getConfiguration;
 import static com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase.execute;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import org.apache.commons.io.filefilter.RegexFileFilter;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ServiceException;
@@ -29,14 +30,14 @@ import com.adaptris.interlok.cloud.RemoteBlobFilterWrapper;
 
 // A new local stack instance; we're going upload, copy, tag, download, get, delete in that order
 // So, sadly we are being really lame, and forcing the ordering...
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class LocalstackServiceTest {
 
   private static final String MSG_CONTENTS = "hello world";
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
-    Assume.assumeTrue(areTestsEnabled());
+    assumeTrue(areTestsEnabled());
   }
 
   @Test
@@ -141,7 +142,7 @@ public class LocalstackServiceTest {
   @Test
   public void test_10_ExtendedCopy_WithoutDestinationBucket() throws Exception {
     // INTERLOK-3544 localstack is broken for the test.
-    Assume.assumeTrue(extendedCopyTests());
+    assumeTrue(extendedCopyTests());
     tagObject(getConfig(S3_UPLOAD_FILENAME));
 
     ExtendedCopyOperation copy = new ExtendedCopyOperation()
@@ -168,7 +169,7 @@ public class LocalstackServiceTest {
   @Test
   public void test_11_DeleteCopy() throws Exception {
     // INTERLOK-3544 localstack is broken for the test.
-    Assume.assumeTrue(extendedCopyTests());
+    assumeTrue(extendedCopyTests());
     DeleteOperation delete =
         new DeleteOperation().withObjectName(getConfig(S3_COPY_TO_FILENAME))
             .withBucket(getConfig(S3_BUCKETNAME));

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/MockedOperationTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/MockedOperationTest.java
@@ -1,8 +1,8 @@
 package com.adaptris.aws.s3;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import java.io.ByteArrayInputStream;
@@ -14,7 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.filefilter.RegexFileFilter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import com.adaptris.aws.s3.acl.S3ObjectAcl;
 import com.adaptris.aws.s3.acl.S3ObjectAclGrant;

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/S3ObjectMetadataTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/S3ObjectMetadataTest.java
@@ -1,11 +1,11 @@
 package com.adaptris.aws.s3;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import com.adaptris.aws.s3.meta.S3ContentDisposition;
 import com.adaptris.aws.s3.meta.S3ContentEncoding;
 import com.adaptris.aws.s3.meta.S3ContentLanguage;
@@ -70,10 +70,8 @@ public class S3ObjectMetadataTest {
     ObjectMetadata meta = new ObjectMetadata();
     om.apply(msg, meta);
     Date expirationDate = meta.getHttpExpiresDate();
-    assertTrue("Expiration date too small",
-        expirationDate.getTime() > (new Date().getTime() + 9000));
-    assertTrue("Expiration date too large",
-        expirationDate.getTime() < (new Date().getTime() + 11000));
+    assertTrue(expirationDate.getTime() > (new Date().getTime() + 9000),"Expiration date too small");
+    assertTrue(expirationDate.getTime() < (new Date().getTime() + 11000), "Expiration date too large");
   }
 
 

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/S3OperationTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/S3OperationTest.java
@@ -16,9 +16,9 @@
 
 package com.adaptris.aws.s3;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import com.adaptris.aws.s3.meta.S3ContentDisposition;
 import com.adaptris.aws.s3.meta.S3ContentEncoding;
 import com.adaptris.aws.s3.meta.S3ContentLanguage;
@@ -150,8 +150,8 @@ public class S3OperationTest {
     assertEquals("expiration time rule id", meta.getExpirationTimeRuleId());
     assertEquals("content encoding", meta.getContentEncoding());
     Date expirationDate = meta.getHttpExpiresDate();
-    assertTrue("Expiration date too small", expirationDate.getTime() > (new Date().getTime() + 9000));
-    assertTrue("Expiration date too large", expirationDate.getTime() < (new Date().getTime() + 11000));
+    assertTrue(expirationDate.getTime() > (new Date().getTime() + 9000), "Expiration date too small");
+    assertTrue(expirationDate.getTime() < (new Date().getTime() + 11000), "Expiration date too large");
     assertEquals(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION, meta.getSSEAlgorithm());
   }
 

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/S3ServiceTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/S3ServiceTest.java
@@ -15,12 +15,12 @@
 */
 
 package com.adaptris.aws.s3;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import com.adaptris.aws.DefaultAWSAuthentication;
 import com.adaptris.aws.StaticCredentialsBuilder;

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/acl/S3ObjectAclTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/acl/S3ObjectAclTest.java
@@ -1,6 +1,6 @@
 package com.adaptris.aws.s3.acl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 import java.util.List;
@@ -9,7 +9,7 @@ import com.amazonaws.services.s3.model.AccessControlList;
 import com.amazonaws.services.s3.model.Grant;
 import com.amazonaws.services.s3.model.Permission;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class S3ObjectAclTest {
 

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/retry/LocalstackRetryStoreTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/retry/LocalstackRetryStoreTest.java
@@ -7,15 +7,16 @@ import static com.adaptris.aws.s3.LocalstackConfig.build;
 import static com.adaptris.aws.s3.LocalstackConfig.createConnection;
 import static com.adaptris.aws.s3.LocalstackConfig.getConfiguration;
 import static com.adaptris.interlok.junit.scaffolding.services.ExampleServiceCase.execute;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import java.util.Iterator;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import com.adaptris.aws.s3.CreateBucketOperation;
 import com.adaptris.aws.s3.DeleteBucketOperation;
 import com.adaptris.aws.s3.S3Service;
@@ -25,12 +26,12 @@ import com.adaptris.core.CoreConstants;
 import com.adaptris.interlok.cloud.RemoteBlob;
 import com.adaptris.interlok.junit.scaffolding.BaseCase;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class LocalstackRetryStoreTest {
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
-    Assume.assumeTrue(areTestsEnabled());
+    assumeTrue(areTestsEnabled());
   }
 
   @Test

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/retry/RetryableBlobIterableTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/retry/RetryableBlobIterableTest.java
@@ -1,11 +1,13 @@
 package com.adaptris.aws.s3.retry;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 import com.adaptris.interlok.cloud.RemoteBlob;
 
 public class RetryableBlobIterableTest {
@@ -19,11 +21,13 @@ public class RetryableBlobIterableTest {
     assertFalse(blob.getName().startsWith("my-prefix/"));
 
   }
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testIterator_Double() throws Exception {
     RetryableBlobIterable itr = new RetryableBlobIterable(build(10), (s) -> nameMapper(s));
-    itr.iterator();
-    itr.iterator();
+    assertThrows(IllegalStateException.class, ()->{
+      itr.iterator();
+      itr.iterator();
+    }, "Iterator run twice, illegalstate exception has been thrown");  
   }
 
   private Iterable<RemoteBlob> build(int count) {

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/retry/S3RetryStoreTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/retry/S3RetryStoreTest.java
@@ -1,7 +1,8 @@
 package com.adaptris.aws.s3.retry;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import java.io.ByteArrayInputStream;
@@ -19,7 +20,7 @@ import java.util.Properties;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import com.adaptris.aws.s3.AmazonS3Connection;
 import com.adaptris.aws.s3.ClientWrapper;
@@ -190,7 +191,7 @@ public class S3RetryStoreTest {
     }
   }
 
-  @Test(expected = InterlokException.class)
+  @Test
   public void testWrite_Exception() throws Exception {
 
     AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
@@ -210,7 +211,9 @@ public class S3RetryStoreTest {
         new S3RetryStore().withBucket("bucket").withPrefix("MyPrefix").withConnection(conn);
     try {
       BaseCase.start(store);
-      store.write(msg);
+      assertThrows(InterlokException.class, ()->{
+        store.write(msg);
+      }, "Failed to write");
     } finally {
       BaseCase.stop(store);
     }
@@ -273,7 +276,7 @@ public class S3RetryStoreTest {
     }
   }
 
-  @Test(expected = InterlokException.class)
+  @Test
   public void testGetMetadata_Exception() throws Exception {
     AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
     TransferManager transferManager = Mockito.mock(TransferManager.class);
@@ -290,8 +293,10 @@ public class S3RetryStoreTest {
         new S3RetryStore().withBucket("bucket").withPrefix("MyPrefix").withConnection(conn);
     try {
       BaseCase.start(store);
-      Map<String, String> map = store.getMetadata("XXXX");
-      assertTrue(map.containsKey(CLASS_UNDER_TEST_KEY));
+      assertThrows(InterlokException.class, ()->{
+        Map<String, String> map = store.getMetadata("XXXX");
+        assertTrue(map.containsKey(CLASS_UNDER_TEST_KEY));
+      }, "Get metadata exception thrown");
     } finally {
       BaseCase.stop(store);
     }
@@ -335,7 +340,7 @@ public class S3RetryStoreTest {
     }
   }
 
-  @Test(expected = InterlokException.class)
+  @Test
   public void testBuildForRetry_Failure() throws Exception {
     AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
     TransferManager transferManager = Mockito.mock(TransferManager.class);
@@ -352,7 +357,9 @@ public class S3RetryStoreTest {
     try {
       BaseCase.start(store);
       Map<String, String> metadata = new HashMap<>();
-      AdaptrisMessage msg = store.buildForRetry("XXX", metadata, null);
+      assertThrows(InterlokException.class, ()->{
+        AdaptrisMessage msg = store.buildForRetry("XXX", metadata, null);
+      }, "Build for retry failed");
     } finally {
       BaseCase.stop(store);
     }

--- a/interlok-aws-sns/src/test/java/com/adaptris/aws/sns/AmazonSNSConnectionTest.java
+++ b/interlok-aws-sns/src/test/java/com/adaptris/aws/sns/AmazonSNSConnectionTest.java
@@ -16,12 +16,12 @@
 
 package com.adaptris.aws.sns;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import com.adaptris.aws.AWSKeysAuthentication;
 import com.adaptris.aws.CustomEndpoint;

--- a/interlok-aws-sns/src/test/java/com/adaptris/aws/sns/LocalstackProducerTest.java
+++ b/interlok-aws-sns/src/test/java/com/adaptris/aws/sns/LocalstackProducerTest.java
@@ -1,14 +1,15 @@
 package com.adaptris.aws.sns;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import java.util.Properties;
 import org.apache.commons.lang3.BooleanUtils;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import com.adaptris.aws.AWSKeysAuthentication;
 import com.adaptris.aws.CustomEndpoint;
 import com.adaptris.aws.StaticCredentialsBuilder;
@@ -25,7 +26,7 @@ import com.amazonaws.services.sns.model.CreateTopicResult;
 // A new local stack instance; we're going publish an SNS message.
 // Note that there must be content to the message otherwise you get a python stack trace in
 // localstack.
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class LocalstackProducerTest {
 
   private static final String TESTS_ENABLED = "localstack.tests.enabled";
@@ -37,9 +38,9 @@ public class LocalstackProducerTest {
 
   private static final String MSG_CONTENTS = "hello world";
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
-    Assume.assumeTrue(areTestsEnabled());
+    assumeTrue(areTestsEnabled());
   }
 
 

--- a/interlok-aws-sns/src/test/java/com/adaptris/aws/sns/TopicPublisherTest.java
+++ b/interlok-aws-sns/src/test/java/com/adaptris/aws/sns/TopicPublisherTest.java
@@ -14,11 +14,11 @@
 
 package com.adaptris.aws.sns;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;

--- a/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/AmazonSQSConnectionTest.java
+++ b/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/AmazonSQSConnectionTest.java
@@ -16,13 +16,13 @@
 
 package com.adaptris.aws.sqs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import com.adaptris.aws.AWSKeysAuthentication;
@@ -46,7 +46,7 @@ public class AmazonSQSConnectionTest {
 
   private AutoCloseable mocking;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     amazonSQSConnection = new AmazonSQSConnection();
 
@@ -60,7 +60,7 @@ public class AmazonSQSConnectionTest {
     amazonSQSConnection.setRegion(Regions.AP_NORTHEAST_1.getName());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     amazonSQSConnection.stop();
     amazonSQSConnection.close();

--- a/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/AwsConsumerTest.java
+++ b/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/AwsConsumerTest.java
@@ -15,7 +15,7 @@
 */
 
 package com.adaptris.aws.sqs;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doThrow;
@@ -29,8 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Consumer;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import com.adaptris.aws.AWSKeysAuthentication;
 import com.adaptris.aws.StaticCredentialsBuilder;
 import com.adaptris.core.AdaptrisMessage;
@@ -64,7 +64,7 @@ public class AwsConsumerTest extends ExampleConsumerCase {
   private AmazonSQSConnection connectionMock;
 
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
 
     sqsClientMock = mock(AmazonSQS.class);

--- a/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/AwsHelperTest.java
+++ b/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/AwsHelperTest.java
@@ -16,12 +16,12 @@
 
 package com.adaptris.aws.sqs;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.GetQueueUrlRequest;
@@ -31,7 +31,7 @@ public class AwsHelperTest extends AwsHelper {
   private static final String QUEUE_URL = "https://localhost/myqueueName";
   private AmazonSQS sqsClientMock;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
 
     sqsClientMock = mock(AmazonSQS.class);

--- a/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/AwsProducerTest.java
+++ b/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/AwsProducerTest.java
@@ -15,11 +15,11 @@
  */
 
 package com.adaptris.aws.sqs;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -29,8 +29,8 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -62,7 +62,7 @@ public class AwsProducerTest extends ExampleProducerCase {
   private AmazonSQSAsync sqsClientMock;
   private AmazonSQSConnection connectionMock;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
 
     producedMessages = new ArrayList<>();

--- a/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/BufferedClientFactoryTest.java
+++ b/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/BufferedClientFactoryTest.java
@@ -16,8 +16,8 @@
 
 package com.adaptris.aws.sqs;
 
-import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.junit.jupiter.api.Test;
 import com.adaptris.aws.AWSKeysAuthentication;
 import com.adaptris.aws.ClientConfigurationBuilder;
 import com.adaptris.aws.EndpointBuilder;

--- a/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/ConsumerMonitorTest.java
+++ b/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/ConsumerMonitorTest.java
@@ -1,9 +1,9 @@
 package com.adaptris.aws.sqs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import com.adaptris.core.runtime.RuntimeInfoComponentFactory;
 import com.adaptris.core.runtime.WorkflowManager;

--- a/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/LocalstackRoundtripTest.java
+++ b/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/LocalstackRoundtripTest.java
@@ -3,16 +3,17 @@ package com.adaptris.aws.sqs;
 import static com.adaptris.aws.sqs.LocalstackHelper.SQS_QUEUE;
 import static com.adaptris.aws.sqs.LocalstackHelper.areTestsEnabled;
 import static com.adaptris.aws.sqs.LocalstackHelper.getProperty;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import org.junit.After;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.FixedIntervalPoller;
@@ -27,25 +28,25 @@ import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.ListQueuesResult;
 
 // A new local stack instance; send some messages, and then receive then.
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class LocalstackRoundtripTest {
 
   private static final String MSG_CONTENTS = "hello world";
   private LocalstackHelper helper;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     helper = new LocalstackHelper();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     helper.shutdown();
   }
 
   @Test
   public void test_01_TestCreateQueue() throws Exception {
-    Assume.assumeTrue(areTestsEnabled());
+    assumeTrue(areTestsEnabled());
     AmazonSQS sqs = helper.getSyncClient();
     sqs.createQueue(getProperty(SQS_QUEUE));
     ListQueuesResult result = sqs.listQueues();
@@ -54,7 +55,7 @@ public class LocalstackRoundtripTest {
 
   @Test
   public void test_02_TestPublish() throws Exception {
-    Assume.assumeTrue(areTestsEnabled());
+    assumeTrue(areTestsEnabled());
     AmazonSQSProducer sqsProducer = new AmazonSQSProducer().withQueue(getProperty(SQS_QUEUE));
     sqsProducer.withMessageAsyncCallback((e) -> {
       try {
@@ -75,7 +76,7 @@ public class LocalstackRoundtripTest {
   public void test_03_TestConsume() throws Exception {
     StandaloneConsumer standaloneConsumer = null;
     try {
-      Assume.assumeTrue(areTestsEnabled());
+      assumeTrue(areTestsEnabled());
       AmazonSQSConsumer consumer = new AmazonSQSConsumer().withQueue(getProperty(SQS_QUEUE));
       AmazonSQSConnection conn = helper.createConnection();
       FixedIntervalPoller poller = new FixedIntervalPoller(new TimeInterval(300L, TimeUnit.MILLISECONDS));
@@ -99,7 +100,7 @@ public class LocalstackRoundtripTest {
 
   @Test
   public void test_99_TestDeleteQueue() throws Exception {
-    Assume.assumeTrue(areTestsEnabled());
+    assumeTrue(areTestsEnabled());
     AmazonSQS sqs = helper.getSyncClient();
     sqs.deleteQueue(helper.toQueueURL(getProperty(SQS_QUEUE)));
   }

--- a/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/UnbufferedClientFactoryTest.java
+++ b/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/UnbufferedClientFactoryTest.java
@@ -16,8 +16,8 @@
 
 package com.adaptris.aws.sqs;
 
-import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.junit.jupiter.api.Test;
 import com.adaptris.aws.AWSKeysAuthentication;
 import com.adaptris.aws.ClientConfigurationBuilder;
 import com.adaptris.aws.EndpointBuilder;

--- a/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/jms/AdvancedSQSImplementationTest.java
+++ b/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/jms/AdvancedSQSImplementationTest.java
@@ -16,11 +16,11 @@
 
 package com.adaptris.aws.sqs.jms;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import org.junit.jupiter.api.Test;
 import com.adaptris.aws.AWSKeysAuthentication;
 import com.adaptris.aws.CustomEndpoint;
 import com.adaptris.aws.DefaultRetryPolicyFactory;

--- a/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/jms/AmazonSQSImplementationTest.java
+++ b/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/jms/AmazonSQSImplementationTest.java
@@ -16,14 +16,14 @@
 
 package com.adaptris.aws.sqs.jms;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import javax.jms.JMSException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import com.adaptris.aws.AWSKeysAuthentication;
 import com.adaptris.aws.DefaultAWSAuthentication;
 import com.adaptris.aws.StaticCredentialsBuilder;

--- a/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/jms/LocalstackJmsTest.java
+++ b/interlok-aws-sqs/src/test/java/com/adaptris/aws/sqs/jms/LocalstackJmsTest.java
@@ -3,14 +3,15 @@ package com.adaptris.aws.sqs.jms;
 import static com.adaptris.aws.sqs.LocalstackHelper.SQS_JMS_QUEUE;
 import static com.adaptris.aws.sqs.LocalstackHelper.areTestsEnabled;
 import static com.adaptris.aws.sqs.LocalstackHelper.getProperty;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import org.junit.After;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import com.adaptris.aws.sqs.LocalstackHelper;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.AdaptrisMessageFactory;
@@ -28,25 +29,25 @@ import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.ListQueuesResult;
 
 // A new local stack instance; send some messages, and then receive then.
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class LocalstackJmsTest {
 
   private static final String MSG_CONTENTS = "hello world";
   private LocalstackHelper helper;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     helper = new LocalstackHelper();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     helper.shutdown();
   }
 
   @Test
   public void test_01_TestCreateQueue() throws Exception {
-    Assume.assumeTrue(areTestsEnabled());
+    assumeTrue(areTestsEnabled());
     AmazonSQS sqs = helper.getSyncClient();
     sqs.createQueue(getProperty(SQS_JMS_QUEUE));
     ListQueuesResult result = sqs.listQueues();
@@ -55,7 +56,7 @@ public class LocalstackJmsTest {
 
   @Test
   public void test_02_TestPublish() throws Exception {
-    Assume.assumeTrue(areTestsEnabled());
+    assumeTrue(areTestsEnabled());
     PtpProducer producer = new PtpProducer().withQueue(getProperty(SQS_JMS_QUEUE));
     JmsConnection conn = helper.createJmsConnection();
     StandaloneProducer sp = new StandaloneProducer(conn, producer);
@@ -69,7 +70,7 @@ public class LocalstackJmsTest {
     StandaloneConsumer standaloneConsumer = null;
     long start = System.currentTimeMillis();
     try {
-      Assume.assumeTrue(areTestsEnabled());
+      assumeTrue(areTestsEnabled());
       PtpConsumer consumer = new PtpConsumer().withQueue(getProperty(SQS_JMS_QUEUE));
       JmsConnection conn = helper.createJmsConnection();
       // System.err.println("Create Objects : " + (System.currentTimeMillis() - start));
@@ -96,7 +97,7 @@ public class LocalstackJmsTest {
 
   @Test
   public void test_99_TestDeleteQueue() throws Exception {
-    Assume.assumeTrue(areTestsEnabled());
+    assumeTrue(areTestsEnabled());
     AmazonSQS sqs = helper.getSyncClient();
     sqs.deleteQueue(helper.toQueueURL(getProperty(SQS_JMS_QUEUE)));
   }


### PR DESCRIPTION
## Motivation

Upgrading unit tests for Junit 4 to 5

## Modification

Junit packages changed to the Junit 5 ones
Gradle build file Junit dependency version increased to 5.
Small tweak to assertThrows method as the ordering of the parameters has changed in Junit 5(where it expects your error message).
'@expected' annotation is no longer valid and must now use 'assertThrows' method instead.
Also updating build files to use Java 17 and the required version of Gradle

## PR Checklist

- [x] been self-reviewed.
- [n/a] Added javadocs for most classes and all non-trivial methods
- [n/a] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [n/a] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [n/a] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [n/a] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [n/a] Checked that new 3rd party dependencies are appropriately licensed
- [n/a] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [n/a] Tested new/updated components in the UI and at runtime in an Interlok instance
- [n/a] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [n/a] Checked that javadoc generation doesn't report errors
- [n/a] Checked the display of the component in the UI
- [n/a] Remove any config/license annotations
- [n/a] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

What's the end result for the user
No changes

## Testing

How can I test this if I'm reviewing this.
If the gradle build is successful and code coverage hasn't dropped then you know it's worked as it means all unit tests ran successfully.