### PR TITLE
adding empty implementations of newly added methods to the RetryStore…

### DIFF
--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/retry/S3RetryStore.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/retry/S3RetryStore.java
@@ -302,7 +302,7 @@ public class S3RetryStore implements RetryStore {
   }
 
   @Override
-  public List<AdaptrisMessage> obtainMessagesToRetry() throws com.adaptris.core.http.jetty.retry.InterlokException {
+  public List<AdaptrisMessage> obtainMessagesToRetry() throws InterlokException {
     return null; // null implementation
   }
 

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/retry/S3RetryStore.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/retry/S3RetryStore.java
@@ -2,6 +2,7 @@ package com.adaptris.aws.s3.retry;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -279,4 +280,35 @@ public class S3RetryStore implements RetryStore {
     }
     return String.format("%s/(.*)/%s", getPrefix(), PAYLOAD_FILE_NAME);
   }
+
+  @Override
+  public void acknowledge(String acknowledgeId) throws InterlokException {
+   // null implementation
+  }
+
+  @Override
+  public void deleteAcknowledged() throws InterlokException {
+   // null implementation 
+  }
+
+  @Override
+  public List<AdaptrisMessage> obtainExpiredMessages() throws InterlokException {
+    return null; // null implementation
+  }
+
+  @Override
+  public void updateRetryCount(String messageId) throws InterlokException {
+   // null implementation  
+  }
+
+  @Override
+  public List<AdaptrisMessage> obtainMessagesToRetry() throws com.adaptris.core.http.jetty.retry.InterlokException {
+    return null; // null implementation
+  }
+
+  @Override
+  public void makeConnection(AdaptrisConnection connection) {
+   // null implementation
+  }
+
 }


### PR DESCRIPTION
… interface.

## Motivation

So the s3 retrystore is inline with the RetryStore interface.

## Modification

Updated S3RetryStore so it has Empty implementations that were newly added to the RetryStore Interface

## PR Checklist

- [x] been self-reviewed.
- [n/a] Added javadocs for most classes and all non-trivial methods
- [n/a] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [n/a] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [n/a] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [n/a] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [n/a] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [n/a] Added unit tests or modified existing tests to cover new code paths
- [n/a] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI
- [x] Remove any config/license annotations
- [n/a] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

No change for the end user for this specific component.

## Testing