### PR TITLE
implements the return of an error message with the s3 retry

### DIFF
--- a/interlok-aws-kinesis/build.gradle
+++ b/interlok-aws-kinesis/build.gradle
@@ -44,7 +44,7 @@ dependencies {
   }
   implementation ("org.apache.kafka:kafka-clients:3.9.1")
   
-  implementation ("org.apache.commons:commons-compress:1.27.1")
+  implementation ("org.apache.commons:commons-compress:1.28.0")
 
   api ("com.google.guava:guava:33.5.0-jre")
   implementation (platform("io.netty:netty-bom:$nettyVersion"))

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/retry/S3RetryStore.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/retry/S3RetryStore.java
@@ -1,12 +1,11 @@
 package com.adaptris.aws.s3.retry;
 
+import java.io.BufferedReader;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Properties;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.validation.Valid;
@@ -131,13 +130,31 @@ public class S3RetryStore implements RetryStore {
   // If the corresponding msg-id/metadata.properties doesn't exist, then it'll fail when we
   // attempt to retry it.
   @Override
-  public Iterable<RemoteBlob> report() throws InterlokException {
+  public Iterable<RemoteBlob> report(boolean includeErrorMessage) throws InterlokException {
     AmazonS3Client s3 = clientWrapper().amazonClient();
     ListObjectsV2Request request =
         new ListObjectsV2Request().withBucketName(getBucket()).withPrefix(getPrefix());
-    return new RetryableBlobIterable(
-        new RemoteBlobIterable(s3, request, (blob) -> blob.getName().endsWith(PAYLOAD_FILE_NAME)),
-        (name) -> toMessageID(name));
+    RemoteBlobIterable baseIterable =
+        new RemoteBlobIterable(s3, request, (blob) -> blob.getName().endsWith(PAYLOAD_FILE_NAME));
+
+    List<RemoteBlob> result = new ArrayList<>();
+    for (RemoteBlob blob : baseIterable) {
+      String msgId = toMessageID(blob.getName());
+      String errorMessage = null;
+      if (includeErrorMessage) {
+        String stacktraceObject = buildObjectName(msgId, STACKTRACE_FILENAME);
+        if (s3.doesObjectExist(getBucket(), stacktraceObject)) {
+          try (InputStream in = getInputStream(stacktraceObject)) {
+            BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
+            errorMessage = reader.readLine();
+          } catch (Exception e) {
+            errorMessage = null;
+          }
+        }
+      }
+      result.add(includeErrorMessage ? new RemoteBlowWithError(blob, errorMessage) : blob);
+    }
+    return result;
   }
 
   @Override
@@ -324,4 +341,20 @@ public class S3RetryStore implements RetryStore {
    // null implementation
   }
 
+  public static class RemoteBlowWithError extends RemoteBlob {
+    private final RemoteBlob remoteBlob;
+    @Getter
+    private final String errorMessage;
+
+    public RemoteBlowWithError(RemoteBlob delegate, String errorMessage) {
+      super();
+      this.remoteBlob = delegate;
+      this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public String getName() {
+      return remoteBlob.getName();
+    }
+  }
 }

--- a/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/retry/S3RetryStore.java
+++ b/interlok-aws-s3/src/main/java/com/adaptris/aws/s3/retry/S3RetryStore.java
@@ -152,7 +152,7 @@ public class S3RetryStore implements RetryStore {
           }
         }
       }
-      result.add(includeErrorMessage ? new RemoteBlowWithError(blob, errorMessage) : blob);
+      result.add(includeErrorMessage ? new RemoteBlobWithError(blob, errorMessage) : blob);
     }
     return result;
   }
@@ -341,12 +341,12 @@ public class S3RetryStore implements RetryStore {
    // null implementation
   }
 
-  public static class RemoteBlowWithError extends RemoteBlob {
+  public static class RemoteBlobWithError extends RemoteBlob {
     private final RemoteBlob remoteBlob;
     @Getter
     private final String errorMessage;
 
-    public RemoteBlowWithError(RemoteBlob delegate, String errorMessage) {
+    public RemoteBlobWithError(RemoteBlob delegate, String errorMessage) {
       super();
       this.remoteBlob = delegate;
       this.errorMessage = errorMessage;

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/retry/LocalstackRetryStoreTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/retry/LocalstackRetryStoreTest.java
@@ -61,7 +61,7 @@ public class LocalstackRetryStoreTest {
         .withPrefix(getConfig(S3_RETRY_PREFIX)).withConnection(createConnection());
     try {
       BaseCase.start(store);
-      Iterable<RemoteBlob> blobs = store.report();
+      Iterable<RemoteBlob> blobs = store.report(false);
       Iterator<RemoteBlob> itr = blobs.iterator();
       assertNotNull(itr);
       assertTrue(itr.hasNext());
@@ -76,7 +76,7 @@ public class LocalstackRetryStoreTest {
         .withPrefix(getConfig(S3_RETRY_PREFIX)).withConnection(createConnection());
     try {
       BaseCase.start(store);
-      Iterable<RemoteBlob> blobs = store.report();
+      Iterable<RemoteBlob> blobs = store.report(false);
       Iterator<RemoteBlob> itr = blobs.iterator();
       assertNotNull(itr);
       assertTrue(itr.hasNext());
@@ -107,11 +107,11 @@ public class LocalstackRetryStoreTest {
         .withPrefix(getConfig(S3_RETRY_PREFIX)).withConnection(createConnection());
     try {
       BaseCase.start(store);
-      Iterable<RemoteBlob> blobs = store.report();
+      Iterable<RemoteBlob> blobs = store.report(false);
       for (RemoteBlob blob : blobs) {
         store.delete(blob.getName());
       }
-      Iterable<RemoteBlob> leftOvers = store.report();
+      Iterable<RemoteBlob> leftOvers = store.report(false);
       assertFalse(leftOvers.iterator().hasNext());
     } finally {
       BaseCase.stop(store);

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/retry/S3RetryStoreTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/retry/S3RetryStoreTest.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -117,8 +116,8 @@ public class S3RetryStoreTest {
       Iterable<RemoteBlob> blobs = store.report(true);
       List<String> errorMessages = new ArrayList<>();
       for (RemoteBlob blob : blobs) {
-        if (blob instanceof S3RetryStore.RemoteBlowWithError) {
-          errorMessages.add(((S3RetryStore.RemoteBlowWithError) blob).getErrorMessage());
+        if (blob instanceof S3RetryStore.RemoteBlobWithError) {
+          errorMessages.add(((S3RetryStore.RemoteBlobWithError) blob).getErrorMessage());
         }
       }
       assertTrue(errorMessages.contains(errorMsg));
@@ -155,8 +154,8 @@ public class S3RetryStoreTest {
       BaseCase.start(store);
       Iterable<RemoteBlob> blobs = store.report(true);
       for (RemoteBlob blob : blobs) {
-        if (blob instanceof S3RetryStore.RemoteBlowWithError) {
-            assertNull(((S3RetryStore.RemoteBlowWithError) blob).getErrorMessage());
+        if (blob instanceof S3RetryStore.RemoteBlobWithError) {
+            assertNull(((S3RetryStore.RemoteBlobWithError) blob).getErrorMessage());
         }
       }
     } finally {
@@ -491,8 +490,8 @@ public class S3RetryStoreTest {
     RemoteBlob mockBlob = Mockito.mock(RemoteBlob.class);
     Mockito.when(mockBlob.getName()).thenReturn(expectedName);
 
-    S3RetryStore.RemoteBlowWithError blowWithError =
-        new S3RetryStore.RemoteBlowWithError(mockBlob, "error message");
+    S3RetryStore.RemoteBlobWithError blowWithError =
+        new S3RetryStore.RemoteBlobWithError(mockBlob, "error message");
 
     assertEquals(expectedName, blowWithError.getName());
   }

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/retry/S3RetryStoreTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/retry/S3RetryStoreTest.java
@@ -485,6 +485,18 @@ public class S3RetryStoreTest {
     }
   }
 
+  @Test
+  public void testGetNameDelegatesToRemoteBlob() {
+    String expectedName = "MyPrefix/1234/payload.blob";
+    RemoteBlob mockBlob = Mockito.mock(RemoteBlob.class);
+    Mockito.when(mockBlob.getName()).thenReturn(expectedName);
+
+    S3RetryStore.RemoteBlowWithError blowWithError =
+        new S3RetryStore.RemoteBlowWithError(mockBlob, "error message");
+
+    assertEquals(expectedName, blowWithError.getName());
+  }
+
   private AmazonS3Connection buildConnection(ClientWrapper wrapper) {
     AmazonS3Connection connection = Mockito.mock(AmazonS3Connection.class);
     Mockito.when(connection.retrieveConnection(ClientWrapper.class)).thenReturn(wrapper);

--- a/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/retry/S3RetryStoreTest.java
+++ b/interlok-aws-s3/src/test/java/com/adaptris/aws/s3/retry/S3RetryStoreTest.java
@@ -1,8 +1,6 @@
 package com.adaptris.aws.s3.retry;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import java.io.ByteArrayInputStream;
@@ -61,10 +59,6 @@ public class S3RetryStoreTest {
     ListObjectsV2Result result = Mockito.mock(ListObjectsV2Result.class);
     String msgId1 = UUID.randomUUID().toString();
     String msgId2 = UUID.randomUUID().toString();
-    S3ObjectSummary sbase = createSummary("bucket", msgId1 + "/payload.blob");
-    S3ObjectSummary s1 = createSummary("bucket", msgId1 + "/metadata.properties");
-    S3ObjectSummary s2 = createSummary("bucket", msgId2 + "/payload.blob");
-    S3ObjectSummary s3 = createSummary("bucket", msgId2 + "/metadata.properties");
 
     List<S3ObjectSummary> list = new ArrayList<>(
         Arrays.asList(createSummary("bucket", "MyPrefix/" + msgId1 + "/payload.blob"),
@@ -79,16 +73,96 @@ public class S3RetryStoreTest {
         new S3RetryStore().withBucket("bucket").withPrefix("MyPrefix").withConnection(conn);
     try {
       BaseCase.start(store);
-      Iterable<RemoteBlob> blobs = store.report();
+      Iterable<RemoteBlob> blobs = store.report(false);
       List<String> blobNames = StreamSupport.stream(blobs.spliterator(), false)
-          .map((blob) -> blob.getName()).collect(Collectors.toList());
-      assertTrue(blobNames.contains(msgId1));
-      assertTrue(blobNames.contains(msgId2));
+          .map(RemoteBlob::getName).toList();
+      assertTrue(blobNames.stream().anyMatch(name -> name.contains(msgId1)));
+      assertTrue(blobNames.stream().anyMatch(name -> name.contains(msgId2)));
     } finally {
       BaseCase.stop(store);
     }
   }
 
+  @Test
+  public void testReportWithErrorMessage() throws Exception {
+    AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
+    TransferManager transferManager = Mockito.mock(TransferManager.class);
+    ClientWrapper wrapper = Mockito.mock(ClientWrapper.class);
+    Mockito.when(wrapper.amazonClient()).thenReturn(client);
+    Mockito.when(wrapper.transferManager()).thenReturn(transferManager);
+
+    AmazonS3Connection conn = buildConnection(wrapper);
+
+    ListObjectsV2Result result = Mockito.mock(ListObjectsV2Result.class);
+    String msgId = UUID.randomUUID().toString();
+    List<S3ObjectSummary> list = Arrays.asList(
+        createSummary("bucket", "MyPrefix/" + msgId + "/payload.blob"),
+        createSummary("bucket", "MyPrefix/" + msgId + "/metadata.properties")
+    );
+    Mockito.when(result.getObjectSummaries()).thenReturn(list);
+    Mockito.when(client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(result);
+
+    String stacktraceObject = "MyPrefix/" + msgId + "/stacktrace.txt";
+    Mockito.when(client.doesObjectExist("bucket", stacktraceObject)).thenReturn(true);
+    S3Object s3Object = Mockito.mock(S3Object.class);
+    String errorMsg = "This is an error message";
+    S3ObjectInputStream inputStream = new S3ObjectInputStream(
+        new ByteArrayInputStream(errorMsg.getBytes(StandardCharsets.UTF_8)), null);
+    Mockito.when(s3Object.getObjectContent()).thenReturn(inputStream);
+    Mockito.when(client.getObject(any(GetObjectRequest.class))).thenReturn(s3Object);
+
+    S3RetryStore store = new S3RetryStore().withBucket("bucket").withPrefix("MyPrefix").withConnection(conn);
+    try {
+      BaseCase.start(store);
+      Iterable<RemoteBlob> blobs = store.report(true);
+      List<String> errorMessages = new ArrayList<>();
+      for (RemoteBlob blob : blobs) {
+        if (blob instanceof S3RetryStore.RemoteBlowWithError) {
+          errorMessages.add(((S3RetryStore.RemoteBlowWithError) blob).getErrorMessage());
+        }
+      }
+      assertTrue(errorMessages.contains(errorMsg));
+    } finally {
+      BaseCase.stop(store);
+    }
+  }
+
+  @Test
+  public void testReportWithErrorMessage_ExceptionInStacktrace() throws Exception {
+    AmazonS3Client client = Mockito.mock(AmazonS3Client.class);
+    TransferManager transferManager = Mockito.mock(TransferManager.class);
+    ClientWrapper wrapper = Mockito.mock(ClientWrapper.class);
+    Mockito.when(wrapper.amazonClient()).thenReturn(client);
+    Mockito.when(wrapper.transferManager()).thenReturn(transferManager);
+
+    AmazonS3Connection conn = buildConnection(wrapper);
+
+    String msgId = UUID.randomUUID().toString();
+    List<S3ObjectSummary> list = Arrays.asList(
+        createSummary("bucket", "MyPrefix/" + msgId + "/payload.blob"),
+        createSummary("bucket", "MyPrefix/" + msgId + "/metadata.properties")
+    );
+    ListObjectsV2Result result = Mockito.mock(ListObjectsV2Result.class);
+    Mockito.when(result.getObjectSummaries()).thenReturn(list);
+    Mockito.when(client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(result);
+
+    String stacktraceObject = "MyPrefix/" + msgId + "/stacktrace.txt";
+    Mockito.when(client.doesObjectExist("bucket", stacktraceObject)).thenReturn(true);
+    Mockito.when(client.getObject(any(GetObjectRequest.class))).thenThrow(new RuntimeException("Simulated error"));
+
+    S3RetryStore store = new S3RetryStore().withBucket("bucket").withPrefix("MyPrefix").withConnection(conn);
+    try {
+      BaseCase.start(store);
+      Iterable<RemoteBlob> blobs = store.report(true);
+      for (RemoteBlob blob : blobs) {
+        if (blob instanceof S3RetryStore.RemoteBlowWithError) {
+            assertNull(((S3RetryStore.RemoteBlowWithError) blob).getErrorMessage());
+        }
+      }
+    } finally {
+      BaseCase.stop(store);
+    }
+  }
 
   // Designed to check to toMessageId method and other things that are predicated on getPrefix
   // it's all about the coverage...

--- a/interlok-aws2-s3/src/main/java/com/adaptris/aws2/s3/retry/S3RetryStore.java
+++ b/interlok-aws2-s3/src/main/java/com/adaptris/aws2/s3/retry/S3RetryStore.java
@@ -160,7 +160,7 @@ public class S3RetryStore implements RetryStore {
         }
       }
       if (includeErrorMessage) {
-        result.add(new RemoteBlowWithError(blob, errorMessage));
+        result.add(new RemoteBlobWithError(blob, errorMessage));
       } else {
         result.add(blob);
       }
@@ -356,12 +356,12 @@ public class S3RetryStore implements RetryStore {
    // null implementation
   }
 
-  public static class RemoteBlowWithError extends RemoteBlob {
+  public static class RemoteBlobWithError extends RemoteBlob {
     private final RemoteBlob remoteBlob;
     @Getter
     private final String errorMessage;
 
-    public RemoteBlowWithError(RemoteBlob delegate, String errorMessage) {
+    public RemoteBlobWithError(RemoteBlob delegate, String errorMessage) {
       super();
       this.remoteBlob = delegate;
       this.errorMessage = errorMessage;

--- a/interlok-aws2-s3/src/main/java/com/adaptris/aws2/s3/retry/S3RetryStore.java
+++ b/interlok-aws2-s3/src/main/java/com/adaptris/aws2/s3/retry/S3RetryStore.java
@@ -133,11 +133,39 @@ public class S3RetryStore implements RetryStore {
   // If the corresponding msg-id/metadata.properties doesn't exist, then it'll fail when we
   // attempt to retry it.
   @Override
-  public Iterable<RemoteBlob> report() throws InterlokException {
+  public Iterable<RemoteBlob> report(boolean includeErrorMessage) throws InterlokException {
     S3Client s3 = clientWrapper().amazonClient();
     ListObjectsV2Request.Builder requestBuilder = ListObjectsV2Request.builder();
     requestBuilder.bucket(getBucket()).prefix(getPrefix());
-    return new RetryableBlobIterable(new RemoteBlobIterable(s3, requestBuilder.build(), (blob) -> blob.getName().endsWith(PAYLOAD_FILE_NAME)), (name) -> toMessageID(name));
+    RemoteBlobIterable baseIterable =
+        new RemoteBlobIterable(s3, requestBuilder.build(), (blob) -> blob.getName().endsWith(PAYLOAD_FILE_NAME));
+
+    List<RemoteBlob> result = new java.util.ArrayList<>();
+    for (RemoteBlob blob : baseIterable) {
+      String msgId = toMessageID(blob.getName());
+      String errorMessage = null;
+      if (includeErrorMessage) {
+        String stacktraceObject = buildObjectName(msgId, STACKTRACE_FILENAME);
+        try {
+          // Try to get the stacktrace file, if it exists
+          GetObjectRequest.Builder getBuilder = GetObjectRequest.builder()
+              .bucket(getBucket())
+              .key(stacktraceObject);
+          try (InputStream in = s3.getObject(getBuilder.build())) {
+            java.io.BufferedReader reader = new java.io.BufferedReader(new java.io.InputStreamReader(in, StandardCharsets.UTF_8));
+            errorMessage = reader.readLine();
+          }
+        } catch (Exception e) {
+          errorMessage = null;
+        }
+      }
+      if (includeErrorMessage) {
+        result.add(new RemoteBlowWithError(blob, errorMessage));
+      } else {
+        result.add(blob);
+      }
+    }
+    return result;
   }
 
   @Override
@@ -326,5 +354,22 @@ public class S3RetryStore implements RetryStore {
   @Override
   public void makeConnection(AdaptrisConnection connection) {
    // null implementation
+  }
+
+  public static class RemoteBlowWithError extends RemoteBlob {
+    private final RemoteBlob remoteBlob;
+    @Getter
+    private final String errorMessage;
+
+    public RemoteBlowWithError(RemoteBlob delegate, String errorMessage) {
+      super();
+      this.remoteBlob = delegate;
+      this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public String getName() {
+      return remoteBlob.getName();
+    }
   }
 }

--- a/interlok-aws2-s3/src/test/java/com/adaptris/aws2/s3/retry/LocalstackRetryStoreTest.java
+++ b/interlok-aws2-s3/src/test/java/com/adaptris/aws2/s3/retry/LocalstackRetryStoreTest.java
@@ -64,7 +64,7 @@ public class LocalstackRetryStoreTest {
         .withPrefix(getConfig(S3_RETRY_PREFIX)).withConnection(createConnection());
     try {
       BaseCase.start(store);
-      Iterable<RemoteBlob> blobs = store.report();
+      Iterable<RemoteBlob> blobs = store.report(false);
       Iterator<RemoteBlob> itr = blobs.iterator();
       assertNotNull(itr);
       assertTrue(itr.hasNext());
@@ -79,7 +79,7 @@ public class LocalstackRetryStoreTest {
         .withPrefix(getConfig(S3_RETRY_PREFIX)).withConnection(createConnection());
     try {
       BaseCase.start(store);
-      Iterable<RemoteBlob> blobs = store.report();
+      Iterable<RemoteBlob> blobs = store.report(false);
       Iterator<RemoteBlob> itr = blobs.iterator();
       assertNotNull(itr);
       assertTrue(itr.hasNext());
@@ -110,11 +110,11 @@ public class LocalstackRetryStoreTest {
         .withPrefix(getConfig(S3_RETRY_PREFIX)).withConnection(createConnection());
     try {
       BaseCase.start(store);
-      Iterable<RemoteBlob> blobs = store.report();
+      Iterable<RemoteBlob> blobs = store.report(false);
       for (RemoteBlob blob : blobs) {
         store.delete(blob.getName());
       }
-      Iterable<RemoteBlob> leftOvers = store.report();
+      Iterable<RemoteBlob> leftOvers = store.report(false);
       assertFalse(leftOvers.iterator().hasNext());
     } finally {
       BaseCase.stop(store);

--- a/interlok-aws2-s3/src/test/java/com/adaptris/aws2/s3/retry/S3RetryStoreTest.java
+++ b/interlok-aws2-s3/src/test/java/com/adaptris/aws2/s3/retry/S3RetryStoreTest.java
@@ -73,15 +73,82 @@ public class S3RetryStoreTest extends BaseCase {
 
     try {
       start(store);
-      Iterable<RemoteBlob> blobs = store.report();
+      Iterable<RemoteBlob> blobs = store.report(false);
       List<String> blobNames = StreamSupport.stream(blobs.spliterator(), false)
-          .map((blob) -> blob.getName()).collect(Collectors.toList());
-      assertTrue(blobNames.contains(msgId1));
-      assertTrue(blobNames.contains(msgId2));
+          .map(RemoteBlob::getName).toList();
+      assertTrue(blobNames.stream().anyMatch(name -> name.contains(msgId1)));
+      assertTrue(blobNames.stream().anyMatch(name -> name.contains(msgId2)));
     } finally {
       stop(store);
     }
   }
+
+    @Test
+    public void testReportWithErrorMessage_Success() throws Exception {
+      S3Client client = Mockito.mock(S3Client.class);
+      ClientWrapper wrapper = Mockito.mock(ClientWrapper.class);
+      Mockito.when(wrapper.amazonClient()).thenReturn(client);
+
+      AmazonS3Connection conn = buildConnection(wrapper);
+
+      String msgId = UUID.randomUUID().toString();
+      List<S3Object> list = Arrays.asList(
+          createSummary("bucket", "MyPrefix/" + msgId + "/payload.blob"),
+          createSummary("bucket", "MyPrefix/" + msgId + "/metadata.properties")
+      );
+      ListObjectsV2Response result = Mockito.mock(ListObjectsV2Response.class);
+      Mockito.when(result.contents()).thenReturn(list);
+      Mockito.when(client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(result);
+
+      // Mock stacktrace.txt content
+      String stacktraceContent = "Simulated error message";
+      ByteArrayInputStream stacktraceStream = new ByteArrayInputStream(stacktraceContent.getBytes(StandardCharsets.UTF_8));
+      ResponseInputStream responseStream = new ResponseInputStream(Mockito.mock(S3Object.class), AbortableInputStream.create(stacktraceStream));
+      Mockito.when(client.getObject(any(GetObjectRequest.class))).thenReturn(responseStream);
+
+      S3RetryStore store = new S3RetryStore().withBucket("bucket").withPrefix("MyPrefix").withConnection(conn);
+      try {
+        start(store);
+        Iterable<RemoteBlob> blobs = store.report(true);
+        for (RemoteBlob blob : blobs) {
+          assertInstanceOf(S3RetryStore.RemoteBlowWithError.class, blob);
+          assertEquals(stacktraceContent, ((S3RetryStore.RemoteBlowWithError) blob).getErrorMessage());
+        }
+      } finally {
+        stop(store);
+      }
+    }
+
+    @Test
+    public void testReportWithErrorMessage_Exception() throws Exception {
+      S3Client client = Mockito.mock(S3Client.class);
+      ClientWrapper wrapper = Mockito.mock(ClientWrapper.class);
+      Mockito.when(wrapper.amazonClient()).thenReturn(client);
+
+      AmazonS3Connection conn = buildConnection(wrapper);
+
+      String msgId = UUID.randomUUID().toString();
+      List<S3Object> list = Arrays.asList(
+          createSummary("bucket", "MyPrefix/" + msgId + "/payload.blob"),
+          createSummary("bucket", "MyPrefix/" + msgId + "/metadata.properties")
+      );
+      ListObjectsV2Response result = Mockito.mock(ListObjectsV2Response.class);
+      Mockito.when(result.contents()).thenReturn(list);
+      Mockito.when(client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(result);
+      Mockito.when(client.getObject(any(GetObjectRequest.class))).thenThrow(new RuntimeException("Simulated error"));
+
+      S3RetryStore store = new S3RetryStore().withBucket("bucket").withPrefix("MyPrefix").withConnection(conn);
+      try {
+        start(store);
+        Iterable<RemoteBlob> blobs = store.report(true);
+        for (RemoteBlob blob : blobs) {
+          assertInstanceOf(S3RetryStore.RemoteBlowWithError.class, blob);
+          assertNull(((S3RetryStore.RemoteBlowWithError) blob).getErrorMessage());
+        }
+      } finally {
+        stop(store);
+      }
+    }
 
 
   // Designed to check to toMessageId method and other things that are predicated on getPrefix

--- a/interlok-aws2-s3/src/test/java/com/adaptris/aws2/s3/retry/S3RetryStoreTest.java
+++ b/interlok-aws2-s3/src/test/java/com/adaptris/aws2/s3/retry/S3RetryStoreTest.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import org.junit.jupiter.api.Assertions;
@@ -111,8 +110,8 @@ public class S3RetryStoreTest extends BaseCase {
         start(store);
         Iterable<RemoteBlob> blobs = store.report(true);
         for (RemoteBlob blob : blobs) {
-          assertInstanceOf(S3RetryStore.RemoteBlowWithError.class, blob);
-          assertEquals(stacktraceContent, ((S3RetryStore.RemoteBlowWithError) blob).getErrorMessage());
+          assertInstanceOf(S3RetryStore.RemoteBlobWithError.class, blob);
+          assertEquals(stacktraceContent, ((S3RetryStore.RemoteBlobWithError) blob).getErrorMessage());
         }
       } finally {
         stop(store);
@@ -142,8 +141,8 @@ public class S3RetryStoreTest extends BaseCase {
         start(store);
         Iterable<RemoteBlob> blobs = store.report(true);
         for (RemoteBlob blob : blobs) {
-          assertInstanceOf(S3RetryStore.RemoteBlowWithError.class, blob);
-          assertNull(((S3RetryStore.RemoteBlowWithError) blob).getErrorMessage());
+          assertInstanceOf(S3RetryStore.RemoteBlobWithError.class, blob);
+          assertNull(((S3RetryStore.RemoteBlobWithError) blob).getErrorMessage());
         }
       } finally {
         stop(store);


### PR DESCRIPTION
## Modification

Updates the S3RetryStore in both AWS v1 and v2 to return an error message with a report if available as default. This can be disabled using a configurable http parameter as per the interlok-core update here - https://github.com/adaptris/interlok/pull/2027

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [x] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [x] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI
- [x] Remove any config/license annotations
- [x] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".
