### PR TITLE
S3 Retry Store Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,21 @@ Caused by: java.io.IOException: Cannot run program "/tmp/amazon-kinesis-producer
         ... 5 common frames omitted
 Caused by: java.io.IOException: error=2, No such file or directory
 ```
+
+## AWS S3
+
+### S3 Retry Store with Podman
+
+To run the S3 retry store locally with test data:
+
+**Prerequisites:**
+- Podman (or Docker)
+- AWS CLI (`pip install awscli`)
+
+**Start LocalStack:**
+```bash
+cd interlok-aws2-s3
+podman-compose -f podman-compose.yml up
+```
+
+This starts a LocalStack S3 instance on `http://localhost:4566` with the `init-s3-retry-store.sh` script automatically creating a test bucket and example failed messages.

--- a/interlok-aws2-s3/init-s3-retry-store.sh
+++ b/interlok-aws2-s3/init-s3-retry-store.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+aws s3 mb s3://retry-store --endpoint-url http://localhost:4566
+
+# Set up AWS CLI to use LocalStack
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_DEFAULT_REGION=eu-west-2
+
+# Create a bucket (if it doesn't exist)
+aws s3 mb s3://retry-store --endpoint-url http://localhost:4566
+
+# Create example failed message 1
+MSG_ID_1="msg-001-abc123"
+aws s3 cp - s3://retry-store/${MSG_ID_1}/payload.blob \
+  --endpoint-url http://localhost:4566 \
+  <<< "This is test payload content"
+
+echo "test.metadata=value1" | \
+aws s3 cp - s3://retry-store/${MSG_ID_1}/metadata.properties \
+  --endpoint-url http://localhost:4566
+
+echo "java.lang.RuntimeException: Test error occurred" | \
+aws s3 cp - s3://retry-store/${MSG_ID_1}/stacktrace.txt \
+  --endpoint-url http://localhost:4566
+
+# Create example failed message 2
+MSG_ID_2="msg-002-def456"
+aws s3 cp - s3://retry-store/${MSG_ID_2}/payload.blob \
+  --endpoint-url http://localhost:4566 \
+  <<< "Another test payload"
+
+aws s3 cp - s3://retry-store/${MSG_ID_2}/metadata.properties \
+  --endpoint-url http://localhost:4566 \
+  <<< "key=value"
+
+aws s3 cp - s3://retry-store/${MSG_ID_2}/stacktrace.txt \
+  --endpoint-url http://localhost:4566 \
+  <<< "java.io.IOException: Connection failed"
+
+# Verify the objects were created
+aws s3 ls s3://retry-store --recursive --endpoint-url http://localhost:4566
+

--- a/interlok-aws2-s3/podman-compose.yml
+++ b/interlok-aws2-s3/podman-compose.yml
@@ -1,0 +1,19 @@
+version: "3.8"
+
+services:
+  localstack:
+    container_name: localstack-s3
+    image: localstack/localstack:3.2.0
+    ports:
+      - "4566:4566"
+    environment:
+      SERVICES: s3
+      DEFAULT_REGION: eu-west-2
+      AWS_DEFAULT_REGION: eu-west-2
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      LS_LOG: debug
+      PERSISTENCE: "1"
+    volumes:
+      - ./localstack-data:/var/lib/localstack
+      - ./init-s3-retry-store.sh:/etc/localstack/init/ready.d/init-s3-retry-store.sh

--- a/interlok-aws2-s3/src/main/java/com/adaptris/aws2/s3/retry/S3RetryStore.java
+++ b/interlok-aws2-s3/src/main/java/com/adaptris/aws2/s3/retry/S3RetryStore.java
@@ -140,32 +140,20 @@ public class S3RetryStore implements RetryStore {
     RemoteBlobIterable baseIterable =
         new RemoteBlobIterable(s3, requestBuilder.build(), (blob) -> blob.getName().endsWith(PAYLOAD_FILE_NAME));
 
-    List<RemoteBlob> result = new java.util.ArrayList<>();
-    for (RemoteBlob blob : baseIterable) {
-      String msgId = toMessageID(blob.getName());
-      String errorMessage = null;
-      if (includeErrorMessage) {
-        String stacktraceObject = buildObjectName(msgId, STACKTRACE_FILENAME);
+    if (includeErrorMessage) {
+      return new RetryableBlobIterable(baseIterable, (name) -> {
+        String msgId = toMessageID(name);
+        String errorMessage = null;
         try {
-          // Try to get the stacktrace file, if it exists
-          GetObjectRequest.Builder getBuilder = GetObjectRequest.builder()
-              .bucket(getBucket())
-              .key(stacktraceObject);
-          try (InputStream in = s3.getObject(getBuilder.build())) {
-            java.io.BufferedReader reader = new java.io.BufferedReader(new java.io.InputStreamReader(in, StandardCharsets.UTF_8));
-            errorMessage = reader.readLine();
-          }
-        } catch (Exception e) {
-          errorMessage = null;
+          errorMessage = getStacktraceFirstLine(msgId);
+        } catch (InterlokException e) {
+          // If we can't get the stacktrace, just return the msgId without error message
         }
-      }
-      if (includeErrorMessage) {
-        result.add(new RemoteBlobWithError(blob, errorMessage));
-      } else {
-        result.add(blob);
-      }
+        return errorMessage != null ? msgId + " - " + errorMessage : msgId;
+      });
+    } else {
+      return new RetryableBlobIterable(baseIterable, this::toMessageID);
     }
-    return result;
   }
 
   @Override
@@ -354,22 +342,5 @@ public class S3RetryStore implements RetryStore {
   @Override
   public void makeConnection(AdaptrisConnection connection) {
    // null implementation
-  }
-
-  public static class RemoteBlobWithError extends RemoteBlob {
-    private final RemoteBlob remoteBlob;
-    @Getter
-    private final String errorMessage;
-
-    public RemoteBlobWithError(RemoteBlob delegate, String errorMessage) {
-      super();
-      this.remoteBlob = delegate;
-      this.errorMessage = errorMessage;
-    }
-
-    @Override
-    public String getName() {
-      return remoteBlob.getName();
-    }
   }
 }

--- a/interlok-aws2-s3/src/test/java/com/adaptris/aws2/s3/retry/S3RetryStoreTest.java
+++ b/interlok-aws2-s3/src/test/java/com/adaptris/aws2/s3/retry/S3RetryStoreTest.java
@@ -37,6 +37,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -100,9 +101,11 @@ public class S3RetryStoreTest extends BaseCase {
       Mockito.when(client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(result);
 
       // Mock stacktrace.txt content
-      String stacktraceContent = "Simulated error message";
-      ByteArrayInputStream stacktraceStream = new ByteArrayInputStream(stacktraceContent.getBytes(StandardCharsets.UTF_8));
-      ResponseInputStream responseStream = new ResponseInputStream(Mockito.mock(S3Object.class), AbortableInputStream.create(stacktraceStream));
+      String stacktraceContent = "Simulated error message\nSecond line of stacktrace";
+      GetObjectResponse mockResponse = Mockito.mock(GetObjectResponse.class);
+      ResponseInputStream<GetObjectResponse> responseStream = new ResponseInputStream<>(
+          mockResponse,
+          AbortableInputStream.create(new ByteArrayInputStream(stacktraceContent.getBytes(StandardCharsets.UTF_8))));
       Mockito.when(client.getObject(any(GetObjectRequest.class))).thenReturn(responseStream);
 
       S3RetryStore store = new S3RetryStore().withBucket("bucket").withPrefix("MyPrefix").withConnection(conn);
@@ -110,8 +113,9 @@ public class S3RetryStoreTest extends BaseCase {
         start(store);
         Iterable<RemoteBlob> blobs = store.report(true);
         for (RemoteBlob blob : blobs) {
-          assertInstanceOf(S3RetryStore.RemoteBlobWithError.class, blob);
-          assertEquals(stacktraceContent, ((S3RetryStore.RemoteBlobWithError) blob).getErrorMessage());
+          // The blob name should now contain the error message appended to the msgId
+          String expectedName = msgId + " - Simulated error message";
+          assertEquals(expectedName, blob.getName());
         }
       } finally {
         stop(store);
@@ -141,8 +145,8 @@ public class S3RetryStoreTest extends BaseCase {
         start(store);
         Iterable<RemoteBlob> blobs = store.report(true);
         for (RemoteBlob blob : blobs) {
-          assertInstanceOf(S3RetryStore.RemoteBlobWithError.class, blob);
-          assertNull(((S3RetryStore.RemoteBlobWithError) blob).getErrorMessage());
+          // When stacktrace retrieval fails, the blob name should just be the msgId
+          assertEquals(msgId, blob.getName());
         }
       } finally {
         stop(store);
@@ -406,10 +410,9 @@ public class S3RetryStoreTest extends BaseCase {
     AmazonS3Connection conn = buildConnection(wrapper);
 
     // Mock the response object
-    software.amazon.awssdk.services.s3.model.GetObjectResponse mockResponse =
-      Mockito.mock(software.amazon.awssdk.services.s3.model.GetObjectResponse.class);
+    GetObjectResponse mockResponse = Mockito.mock(GetObjectResponse.class);
 
-    ResponseInputStream<software.amazon.awssdk.services.s3.model.GetObjectResponse> responseStream =
+    ResponseInputStream<GetObjectResponse> responseStream =
       new ResponseInputStream<>(mockResponse, AbortableInputStream.create(
         new ByteArrayInputStream(STACKTRACE_CONTENT.getBytes(StandardCharsets.UTF_8))));
 


### PR DESCRIPTION
## Motivation

Rworked S3RetryStore to fix bug with the report method which threw an error.

## Modification

Simplified report method so that RemoteBlobWithError was no longer needed as this is what was throwing the error.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [x] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [x] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI
- [x] Remove any config/license annotations
- [x] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Fixed S3 Retry Store

## Testing

I have tested locally with a localstack s3 container and local adapter instance. 
